### PR TITLE
Add fallback to payee_information for spectre imports

### DIFF
--- a/app/Services/Spectre/Conversion/Routine/GenerateTransactions.php
+++ b/app/Services/Spectre/Conversion/Routine/GenerateTransactions.php
@@ -156,7 +156,7 @@ class GenerateTransactions
             $return['transactions'][0]['destination_id'] = (int) $this->accounts[$spectreAccountId];
 
             // source is the other side:
-            $return['transactions'][0]['source_name'] = $entry['extra']['payee'] ?? '(unknown source account)';
+            $return['transactions'][0]['source_name'] = $entry['extra']['payee'] ?? $entry['extra']['payee_information'] ?? '(unknown source account)';
         }
 
         if (-1 === bccomp($entry['amount'], '0')) {
@@ -167,7 +167,7 @@ class GenerateTransactions
             // source is Spectre:
             $return['transactions'][0]['source_id'] = (int) $this->accounts[$spectreAccountId];
             // dest is shop
-            $return['transactions'][0]['destination_name'] = $entry['extra']['payee'] ?? '(unknown destination account)';
+            $return['transactions'][0]['destination_name'] = $entry['extra']['payee'] ?? $entry['extra']['payee_information'] ?? '(unknown destination account)';
 
         }
         app('log')->debug(sprintf('Parsed Spectre transaction #%d', $entry['id']));


### PR DESCRIPTION
Changes in this pull request:

- Add fallback to payee_information field in spectre importer.
  For accounts connected in spectre via FinTS, the extra.payee field is not set. The name of the other account is provided in the extra.payee_information field.
  
  Example API Response:
```
{
    "id": "1234",
    "account_id": "1234",
    "duplicated": false,
    "mode": "normal",
    "status": "posted",
    "made_on": "2021-12-16",
    "amount": -10.00,
    "currency_code": "EUR",
    "description": " garantierte Debitkartenzahlung",
    "category": "uncategorized",
    "extra": {
        "type": "Other undefined GM species",
        "additional": "SEPA-BASISLASTSCHRIFT",
        "information": "SEPA-BASISLASTSCHRIFTEREF+ XXX",
        "posting_date": "2021-12-16",
        "payee_information": "Buerklin GmbH + Co. K",
        "account_balance_snapshot": 100.00,
        "categorization_confidence": 0
    },
    "created_at": "2022-01-04T20:16:20Z",
    "updated_at": "2022-01-04T20:16:20Z"
},
```


@JC5
