### PR TITLE
Develop

### DIFF
--- a/app/Services/Nordigen/Conversion/Routine/GenerateTransactions.php
+++ b/app/Services/Nordigen/Conversion/Routine/GenerateTransactions.php
@@ -245,7 +245,8 @@ class GenerateTransactions
 
         /* Triodos NL, see https://developer.triodos.com/docs/proprietary-bank-transaction-codes  */
         if (('' === $transactiontype) and ('BA' === $entry->proprietaryBankTransactionCode)) {
-            app('log')->debug('"BetaalAutomaat": assume withdrawal.');
+            $entry->creditorName = explode("\\", $transaction['description'])[0];
+            app('log')->debug(sprintf('"BetaalAutomaat": assume withdrawal for "%s".', $entry->creditorName));
             $transactiontype = 'withdrawal';
 		}	
 

--- a/app/Services/Nordigen/Model/Transaction.php
+++ b/app/Services/Nordigen/Model/Transaction.php
@@ -49,6 +49,7 @@ class Transaction
     public string  $key;
     public string  $mandateId;
     public string  $proprietaryBank;
+    public string  $proprietaryBankTransactionCode;  // Triodos NL, see https://developer.triodos.com/docs/proprietary-bank-transaction-codes
     public string  $purposeCode;
     public string  $remittanceInformationStructured;
     public array   $remittanceInformationStructuredArray;
@@ -107,6 +108,7 @@ class Transaction
         $object->entryReference                         = $array['entryReference'] ?? '';
         $object->mandateId                              = $array['mandateId'] ?? '';
         $object->proprietaryBank                        = $array['proprietaryBank'] ?? '';
+        $object->proprietaryBankTransactionCode         = $array['proprietaryBankTransactionCode'] ?? '';
         $object->purposeCode                            = $array['purposeCode'] ?? '';
         $object->remittanceInformationStructured        = $array['remittanceInformationStructured'] ?? '';
         $object->remittanceInformationStructuredArray   = $array['remittanceInformationStructuredArray'] ?? [];
@@ -187,6 +189,7 @@ class Transaction
         $object->key                                    = $array['key'];
         $object->mandateId                              = $array['mandate_id'];
         $object->proprietaryBank                        = $array['proprietary_bank'];
+        $object->proprietaryBankTransactionCode         = $array['proprietary_bank_transcode'];
         $object->purposeCode                            = $array['purpose_code'];
         $object->remittanceInformationStructured        = $array['remittance_information_structured'];
         $object->remittanceInformationStructuredArray   = $array['remittance_information_structured_array'];
@@ -423,6 +426,7 @@ class Transaction
             'key'                                       => $this->key,
             'mandate_id'                                => $this->mandateId,
             'proprietary_bank'                          => $this->proprietaryBank,
+            'proprietary_bank_transcode'                => $this->proprietaryBankTransactionCode,
             'purpose_code'                              => $this->purposeCode,
             'remittance_information_structured'         => $this->remittanceInformationStructured,
             'remittance_information_structured_array'   => $this->remittanceInformationStructuredArray,


### PR DESCRIPTION
Proposed fix for issue #5788  (https://github.com/firefly-iii/firefly-iii/issues/5788)


"Import from Nordigen" writes all transactions as deposits when the bank is Triodos from the Netherlands. The reason is that all amounts are greater than zero.

I propose a change that function GenerateTransaction bases its decision proposal/withdrawal on other attributes: 

"withdrawal" when there is a creditorName, "deposit" when there is a debtorName, "withdrawal" when Triodos wrote proprietaryBankTransactionCode: "BA".
Otherwise there is still the original assumption, that it's a deposit when the amount is greater than zero, else withdrawal.

@JC5
