### PR TITLE
Ignore invalid debtor IBANs from Nordigen

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,7 +25,9 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Support\Steam;
+use App\Validation\FireflyValidator;
 use Illuminate\Support\ServiceProvider;
+use Validator;
 
 /**
  * Class AppServiceProvider
@@ -54,6 +56,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Validator::resolver(
+            static function ($translator, $data, $rules, $messages) {
+                return new FireflyValidator($translator, $data, $rules, $messages);
+            }
+        );
     }
 }

--- a/app/Services/Nordigen/Model/Transaction.php
+++ b/app/Services/Nordigen/Model/Transaction.php
@@ -30,6 +30,8 @@ use DateTimeInterface;
 use JsonException;
 use Ramsey\Uuid\Uuid;
 
+use Validator;
+
 class Transaction
 {
     public string  $additionalInformation;
@@ -361,6 +363,14 @@ class Transaction
     {
         app('log')->debug(__METHOD__);
         if ('' !== $this->debtorAccountIban) {
+            $data      = ['iban' => $this->debtorAccountIban];
+            $rules     = ['iban' => 'required|iban'];
+            $validator = Validator::make($data, $rules);
+            if ($validator->fails()) {
+                app('log')->warning(sprintf('Source IBAN is "%s" (debtor), but it is invalid, so ignoring', $this->debtorAccountIban));
+                return null;
+            }
+
             app('log')->debug(sprintf('Source IBAN is "%s" (debtor)', $this->debtorAccountIban));
             return $this->debtorAccountIban;
         }

--- a/app/Validation/FireflyValidator.php
+++ b/app/Validation/FireflyValidator.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * FireflyValidator.php
+ * Copyright (c) 2019 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace App\Validation;
+
+use Illuminate\Validation\Validator;
+use Log;
+use ValueError;
+use function is_string;
+
+/**
+ * Class FireflyValidator.
+ */
+class FireflyValidator extends Validator
+{
+    /**
+     * @param mixed $attribute
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function validateIban($attribute, $value): bool
+    {
+        if (null === $value || !is_string($value) || strlen($value) < 6) {
+            return false;
+        }
+        // strip spaces
+        $search  = [
+            "\x20", // normal space
+            "\u{0001}", // start of heading
+            "\u{0002}", // start of text
+            "\u{0003}", // end of text
+            "\u{0004}", // end of transmission
+            "\u{0005}", // enquiry
+            "\u{0006}", // ACK
+            "\u{0007}", // BEL
+            "\u{0008}", // backspace
+            "\u{000E}", // shift out
+            "\u{000F}", // shift in
+            "\u{0010}", // data link escape
+            "\u{0011}", // DC1
+            "\u{0012}", // DC2
+            "\u{0013}", // DC3
+            "\u{0014}", // DC4
+            "\u{0015}", // NAK
+            "\u{0016}", // SYN
+            "\u{0017}", // ETB
+            "\u{0018}", // CAN
+            "\u{0019}", // EM
+            "\u{001A}", // SUB
+            "\u{001B}", // escape
+            "\u{001C}", // file separator
+            "\u{001D}", // group separator
+            "\u{001E}", // record separator
+            "\u{001F}", // unit separator
+            "\u{007F}", // DEL
+            "\u{00A0}", // non-breaking space
+            "\u{1680}", // ogham space mark
+            "\u{180E}", // mongolian vowel separator
+            "\u{2000}", // en quad
+            "\u{2001}", // em quad
+            "\u{2002}", // en space
+            "\u{2003}", // em space
+            "\u{2004}", // three-per-em space
+            "\u{2005}", // four-per-em space
+            "\u{2006}", // six-per-em space
+            "\u{2007}", // figure space
+            "\u{2008}", // punctuation space
+            "\u{2009}", // thin space
+            "\u{200A}", // hair space
+            "\u{200B}", // zero width space
+            "\u{202F}", // narrow no-break space
+            "\u{3000}", // ideographic space
+            "\u{FEFF}", // zero width no -break space
+            '-',
+            '?',
+        ];
+        $replace = '';
+        $value   = str_replace($search, $replace, $value);
+        $value   = strtoupper($value);
+
+        // replace characters outside of ASCI range.
+        $value   = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $value);
+        $search  = [' ', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
+        $replace = ['', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31',
+                    '32', '33', '34', '35',];
+
+        // take
+        $first = substr($value, 0, 4);
+        $last  = substr($value, 4);
+        $iban  = $last . $first;
+        $iban  = trim(str_replace($search, $replace, $iban));
+        if (0 === strlen($iban)) {
+            return false;
+        }
+        try {
+            $checksum = bcmod($iban, '97');
+        } catch (ValueError $e) {
+            $message = sprintf('Could not validate IBAN check value "%s" (IBAN "%s")', $iban, $value);
+            Log::error($message);
+            Log::error($e->getTraceAsString());
+
+            return false;
+        }
+
+        return 1 === (int)$checksum;
+    }
+}


### PR DESCRIPTION
Fixes issue https://github.com/firefly-iii/firefly-iii/issues/5953

Changes in this pull request:

- If a transaction from Nordigen contains an invalid IBAN from a debtor account, that IBAN gets discarded

I've used the validateIban function from firefly-iii.

I've tested this locally and it works.
Feel free to make changes if needed.

@JC5
