### PR TITLE
Transaction empty description -> "no description"

### DIFF
--- a/app/Services/Nordigen/Conversion/Routine/GenerateTransactions.php
+++ b/app/Services/Nordigen/Conversion/Routine/GenerateTransactions.php
@@ -220,7 +220,7 @@ class GenerateTransactions
             'date'               => $entry->getDate()->format('Y-m-d'),
             'datetime'           => $entry->getDate()->toW3cString(),
             'amount'             => $entry->transactionAmount,
-            'description'        => $entry->getDescription(),
+            'description'        => '' !== trim((string)($entry->getDescription() ?? '')) ? $entry->getDescription() : '(no description)',
             'payment_date'       => is_null($valueDate) ? '' : $valueDate->format('Y-m-d'),
             'order'              => 0,
             'currency_code'      => $entry->currencyCode,

--- a/app/Services/Shared/Import/Routine/ApiSubmitter.php
+++ b/app/Services/Shared/Import/Routine/ApiSubmitter.php
@@ -359,9 +359,6 @@ class ApiSubmitter
                         app('log')->debug(sprintf('Replaced source name "%s" with a reference to account id #%d', $source, $this->mapping[0][$source]));
                     }
                 }
-                if('' === trim((string)($transaction['description'] ?? '')) {
-                    $transaction['description'] = '(no description)';
-                }
                 $line['transactions'][$index] = $this->updateTransactionType($transaction);
             }
         }

--- a/app/Services/Shared/Import/Routine/ApiSubmitter.php
+++ b/app/Services/Shared/Import/Routine/ApiSubmitter.php
@@ -359,6 +359,9 @@ class ApiSubmitter
                         app('log')->debug(sprintf('Replaced source name "%s" with a reference to account id #%d', $source, $this->mapping[0][$source]));
                     }
                 }
+                if (empty(trim($transaction['description']))){
+                    $transaction['description'] = '(no description)';
+                }
                 $line['transactions'][$index] = $this->updateTransactionType($transaction);
             }
         }

--- a/app/Services/Shared/Import/Routine/ApiSubmitter.php
+++ b/app/Services/Shared/Import/Routine/ApiSubmitter.php
@@ -359,7 +359,7 @@ class ApiSubmitter
                         app('log')->debug(sprintf('Replaced source name "%s" with a reference to account id #%d', $source, $this->mapping[0][$source]));
                     }
                 }
-                if (empty(trim($transaction['description']))){
+                if('' === trim((string)($transaction['description'] ?? '')) {
                     $transaction['description'] = '(no description)';
                 }
                 $line['transactions'][$index] = $this->updateTransactionType($transaction);


### PR DESCRIPTION
Not sure if this works, or if this is the place to put it.

Fixes issue #6210

Changes in this pull request:

- Checks for empty description, if it is empty, fill in default: "(no description)"

@JC5
