### PR TITLE
Use additionalInformation as fallback for Nordigen transaction descri…

### DIFF
--- a/app/Services/Nordigen/Model/Transaction.php
+++ b/app/Services/Nordigen/Model/Transaction.php
@@ -285,6 +285,10 @@ class Transaction
             app('log')->debug('Description is now remittanceInformationStructured');
             $description = $this->remittanceInformationStructured;
         }
+        if ('' === $description) {
+            app('log')->debug('Description is now additionalInformation');
+            $description = $this->additionalInformation;
+        }
         $description = trim($description);
 
         if ('' === $description) {


### PR DESCRIPTION
This is how the Nordigen transactions look for me: 

<img width="764" alt="Screenshot 2022-07-19 at 18 47 55" src="https://user-images.githubusercontent.com/46676886/179806071-07167456-65bd-4998-a230-f1df95e46de2.png">

I think it would be nice to preserve the text in `additionalInformation` - perhaps in the `description` field.

Changes in this pull request:

- Use `additionalInformation` as fallback for Nordigen transaction description

@JC5