### PR TITLE
Change PHP docs link

### DIFF
--- a/resources/views/import/004-configure/index.twig
+++ b/resources/views/import/004-configure/index.twig
@@ -243,7 +243,7 @@
                                             Use this box to set the date format as it can be found in your file. You can
                                             use
                                             the format as described
-                                            <a href="https://www.php.net/manual/en/function.date.php">on this page</a>.
+                                            <a href="https://www.php.net/manual/en/datetime.format.php">on this page</a>.
                                             Don't stop playing with this setting until <strong
                                                 id="date_example">1984-09-17</strong> matches what you see in your
                                             importable file.


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:

- Updated the link to PHP docs to point to the page explaining the date format itself.

@JC5
