### PR TITLE
Add health check endpoint

### DIFF
--- a/app/Http/Controllers/HealthcheckController.php
+++ b/app/Http/Controllers/HealthcheckController.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * HealthcheckController.php
+ * Copyright (c) 2021 https://github.com/ajgon and github.com/davidschlachter
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Response;
+
+/**
+ * Class HealthcheckController.
+ */
+class HealthcheckController extends Controller
+{
+    /**
+     * Sends 'OK' info when app is alive
+     *
+     * @return Response
+     */
+    public function check(): Response
+    {
+        return response('OK', 200);
+    }
+
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 Route::get('/', 'IndexController@index')->name('index');
 Route::post('/', 'IndexController@postIndex')->name('index.post');
 Route::get('/debug', 'DebugController@index')->name('debug');
+Route::get('/health', 'HealthcheckController@check')->name('health');
 
 // validate access token:
 Route::get('/token', 'TokenController@index')->name('token.index');


### PR DESCRIPTION
Fixes issue https://github.com/firefly-iii/firefly-iii/issues/6492

Changes in this pull request:

- adds a `/health` endpoint to the `data-importer`, based on https://github.com/firefly-iii/firefly-iii/pull/5153. If the application is running, it returns `OK` with an HTTP 200 status.

(duplicate of #230 which I had opened against `main`)

@JC5
