### PR TITLE
Fix broken link to data mapping docs

### DIFF
--- a/resources/views/import/006-mapping/index.twig
+++ b/resources/views/import/006-mapping/index.twig
@@ -17,7 +17,7 @@
                         <p>
                             Entries in your import may already exist in another form in your own Firefly III
                             instance. Be sure to <a target="_blank"
-                                                    href="https://docs.firefly-iii.org/data-importer/usage/map/">
+                                                    href="https://docs.firefly-iii.org/data-importer/how-to-use/map/">
                                 check out the documentation</a>, because this is where
                             the magic happens.
                         </p>


### PR DESCRIPTION
Changes in this pull request:

Updated the broken link from https://docs.firefly-iii.org/data-importer/usage/map/ to https://docs.firefly-iii.org/data-importer/how-to-use/map/ (current).
