### PR TITLE
Only match account when currency is the same

### DIFF
--- a/app/Support/Internal/MergesAccountLists.php
+++ b/app/Support/Internal/MergesAccountLists.php
@@ -105,7 +105,7 @@ trait MergesAccountLists
 
             if (1 === count($filteredByNumber)) {
                 app('log')->debug(sprintf('Generic account ("%s", "%s") has a single FF3 counter part (#%d, "%s")', $iban, $number, $filteredByNumber[0]->id, $filteredByNumber[0]->name));
-                $entry['firefly_iii_accounts'] = array_merge($filteredByNumber, $filteredByCurrency);
+                $entry['firefly_iii_accounts'] = array_unique(array_merge($filteredByNumber, $filteredByCurrency), SORT_REGULAR);
                 $return[]                      = $entry;
 
                 continue;

--- a/app/Support/Internal/MergesAccountLists.php
+++ b/app/Support/Internal/MergesAccountLists.php
@@ -101,18 +101,16 @@ trait MergesAccountLists
             ];
 
             $filteredByNumber              = $this->filterByAccountNumber($fireflyIII, $iban, $number);
+            $filteredByCurrency            = $this->filterByCurrency($fireflyIII, $currency);
 
             if (1 === count($filteredByNumber)) {
                 app('log')->debug(sprintf('Generic account ("%s", "%s") has a single FF3 counter part (#%d, "%s")', $iban, $number, $filteredByNumber[0]->id, $filteredByNumber[0]->name));
-                $entry['firefly_iii_accounts'] = $filteredByNumber;
+                $entry['firefly_iii_accounts'] = array_merge($filteredByNumber, $filteredByCurrency);
                 $return[]                      = $entry;
 
                 continue;
             }
             app('log')->debug(sprintf('Found %d FF3 accounts with the same IBAN or number ("%s")', count($filteredByNumber), $iban));
-
-            // only currency?
-            $filteredByCurrency            = $this->filterByCurrency($fireflyIII, $currency);
 
             if (count($filteredByCurrency) > 0) {
                 app('log')->debug(sprintf('Generic account ("%s") has %d Firefly III counter part(s) with the same currency %s.', $account->name, count($filteredByCurrency), $currency));


### PR DESCRIPTION
In Revolut you can open accounts in several currencies, but all this accounts share the same IBAN number. This is giving issues in the data importer:
If you add your IBAN number in Firefly to your main currency account, the data importer will force you to link all the accounts to the main account, because the IBAN matches. Then the transactions of those accounts give an error, because the currency of the transaction does not match with the currency of the account.
If you chose to leave the IBAN number of your accounts empty, you can import transactions from all the accounts without any problems. But then transactions from other banks to Revolut will get linked to an Expense account because it won't recognize the IBAN number.

Therefore I've added a check to the match on bank account number. If the currency does not match, the account will not be linked. This way you can link the IBAN number to the main currency, and still import transactions of the other currency accounts.