### PR TITLE
Fixed a small issue with a label targeting the wrong input

### DIFF
--- a/resources/views/import/004-configure/index.twig
+++ b/resources/views/import/004-configure/index.twig
@@ -348,9 +348,9 @@
                                         <div class="form-check">
                                             <input class="form-check-input"
                                                    {% if configuration.isAddImportTag or null == configuration %}checked{% endif %}
-                                                   type="checkbox" id="rules" name="add_import_tag" value="1"
+                                                   type="checkbox" id="add_import_tag" name="add_import_tag" value="1"
                                                    aria-describedby="add_import_tagHelp">
-                                            <label class="form-check-label" for="rules">
+                                            <label class="form-check-label" for="add_import_tag">
                                                 Yes
                                             </label>
                                             <small id="add_import_tagHelp" class="form-text text-muted">


### PR DESCRIPTION
Changes in this pull request:

- Fixes the `for`-tag of a label targeting the input checkbox above it and not the one it should be targeting

@JC5