### PR TITLE
Update Nordigen base url

### DIFF
--- a/config/nordigen.php
+++ b/config/nordigen.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
 return [
     'id'                    => env('NORDIGEN_ID', ''),
     'key'                   => env('NORDIGEN_KEY', ''),
-    'url'                   => 'https://ob.nordigen.com',
+    'url'                   => 'https://bankaccountdata.gocardless.com',
     'use_sandbox'           => env('NORDIGEN_SANDBOX', false),
     'unique_column_options' => [
         'external-id'            => 'External identifier',


### PR DESCRIPTION
I just received an email from GoCardless that the legacy base URL is going to stop on 20th February 

It is the email content:
```
Dear user,

We are contacting you to make sure you are using an up-to-date base_url for the GoCardless Bank Account Data API.
This small but important change which should be easy to make for anyone in your team who has access to the production setup of your service. The new connection string should be:
https://bankaccountdata.gocardless.com/api/v2/

The legacy URLs such as [ob.nordigen.com](http://ob.nordigen.com/) and [ob.gocardless.com](http://ob.gocardless.com/) will stop working on the 20th of February.

If you are using any of our public libraries, they are updated and can be found here:
https://developer.gocardless.com/bank-account-data/libraries

We would also like to inform you that there is maintenance window (with downtime) scheduled for 20.02.2024 between 03:00 and 05:00 UTC. You follow its progress on our statuspage:
https://status.nordigen.com/

If you have any questions, feel free to contact support by replying to this mail and will be happy to assist you.

Working on an ever better service,
Bank Account Data Team
```

Changes in this pull request:

- Base URL of Nordigen
-
-

@JC5