### PR TITLE
add support for using a single bulkconfig.json file for directory imports

### DIFF
--- a/app/Console/AutoImports.php
+++ b/app/Console/AutoImports.php
@@ -109,8 +109,15 @@ trait AutoImports
         $short    = substr($file, 0, -4);
         $jsonFile = sprintf('%s.json', $short);
         $fullJson = sprintf('%s/%s', $directory, $jsonFile);
+        $configJsonExists = file_exists(sprintf("%s/bulkconfig.json", $directory));
+
         if (!file_exists($fullJson)) {
-            $this->warn(sprintf('Can\'t find JSON file "%s" expected to go with CSV file "%s". CSV file will be ignored.', $fullJson, $file));
+            $this->error(sprintf('config json exists: %s',$configJsonExists));
+            if($configJsonExists){
+                $this->error(sprintf('Found \'bulkconfig.json\''));
+                return true;
+            }
+            $this->warn(sprintf('Can\'t find JSON file "%s" expected to go with file "%s". This file will be ignored.', $fullJson, $file));
 
             return false;
         }
@@ -177,6 +184,17 @@ trait AutoImports
         if ('xml' === $this->getExtension($file)) {
             $jsonFile = sprintf('%s/%s.json', $directory, substr($file, 0, -4));
         }
+
+        $configJsonFile = sprintf("%s/bulkconfig.json", $directory);
+        $configJsonExists = file_exists($configJsonFile);
+        $jsonFileExists = file_exists($jsonFile);
+
+        // Should never happen
+        if(!$jsonFileExists && !$configJsonExists){
+            $this->error(sprintf('No json found! Checked for both "%s" and "%s"'), $jsonFile, $configJsonFile);
+        }
+
+        $jsonFile = $jsonFileExists ? $jsonFile : $configJsonFile;
 
         app('log')->debug(sprintf('ImportFile: importable "%s"', $importableFile));
         app('log')->debug(sprintf('ImportFile: JSON       "%s"', $jsonFile));

--- a/app/Console/AutoImports.php
+++ b/app/Console/AutoImports.php
@@ -112,9 +112,8 @@ trait AutoImports
         $configJsonExists = file_exists(sprintf("%s/bulkconfig.json", $directory));
 
         if (!file_exists($fullJson)) {
-            $this->error(sprintf('config json exists: %s',$configJsonExists));
             if($configJsonExists){
-                $this->error(sprintf('Found \'bulkconfig.json\''));
+                $this->line(sprintf('Found \'bulkconfig.json\''));
                 return true;
             }
             $this->warn(sprintf('Can\'t find JSON file "%s" expected to go with file "%s". This file will be ignored.', $fullJson, $file));


### PR DESCRIPTION
Individual .json config files take precedence.
If bulkconfig.json exists in the import directory, it will be used for all files that do not have a matching .json config file. Still throws an error of neither json exists.

@JC5
