### PR TITLE
Case insensitive matching for BankDebitCredit converter

### DIFF
--- a/app/Services/CSV/Converter/BankDebitCredit.php
+++ b/app/Services/CSV/Converter/BankDebitCredit.php
@@ -51,7 +51,10 @@ class BankDebitCredit implements ConverterInterface
             'DBIT', // https://subsembly.com/index.html (Banking4 App)
             'Charge', // not sure which bank but it's insane.
         ];
-        if (in_array(trim($value), $negative, true)) {
+        // 'Dr' should also match 'DR'
+        $negative = array_map('strtolower', $negative); // lower case for better matching
+        
+        if (in_array(strtolower(trim($value)), $negative, true)) {
             return -1;
         }
 


### PR DESCRIPTION
A simple change.

Changes in this pull request:
- The converter for `BankDebitCredit` can now match case insensitively. 

Solved the problem of some exports having 'Dr' instead of 'DR', and all transactions getting passed as Credits

@JC5
