### PR TITLE
Case insensitive matching for BankDebitCredit converter

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,5 +1,6 @@
 name: Code - Run Sonarcloud
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/app/Services/CSV/Converter/BankDebitCredit.php
+++ b/app/Services/CSV/Converter/BankDebitCredit.php
@@ -39,19 +39,22 @@ class BankDebitCredit implements ConverterInterface
     public function convert($value): int
     {
         app('log')->debug('Going to convert ', ['value' => $value]);
+
+        // Note: the array values should be all lowercase
         $negative = [
-            'D', // Old style Rabobank (NL). Short for "Debit"
-            'A', // New style Rabobank (NL). Short for "Af"
-            'DR', // https://old.reddit.com/r/FireflyIII/comments/bn2edf/generic_debitcredit_indicator/
-            'Af', // ING (NL).
-            'Debet', // Triodos (NL)
-            'Debit', // ING (EN), thx Quibus!
-            'debit', // Mint
-            'S', // Volksbank (DE), Short for "Soll"
-            'DBIT', // https://subsembly.com/index.html (Banking4 App)
-            'Charge', // not sure which bank but it's insane.
+            'd', // Old style Rabobank (NL). Short for "Debit"
+            'a', // New style Rabobank (NL). Short for "Af"
+            'dr', // https://old.reddit.com/r/FireflyIII/comments/bn2edf/generic_debitcredit_indicator/
+            'af', // ING (NL).
+            'debet', // Triodos (NL)
+            'debit', // ING (EN), thx Quibus!
+            's', // Volksbank (DE), Short for "Soll"
+            'dbit', // https://subsembly.com/index.html (Banking4 App)
+            'charge', // not sure which bank but it's insane.
         ];
-        if (in_array(trim($value), $negative, true)) {
+
+        // Lowercase the value and trim it for comparison.
+        if (in_array(strtolower(trim($value)), $negative, true)) {
             return -1;
         }
 


### PR DESCRIPTION
A simple change.

Changes in this pull request:

The converter for BankDebitCredit can now match case insensitively.
Solved the problem of some exports having 'Dr' instead of 'DR', and all transactions getting passed as Credits

@JC5