### PR TITLE
Add DB as Debit indicator

### DIFF
--- a/app/Services/CSV/Converter/BankDebitCredit.php
+++ b/app/Services/CSV/Converter/BankDebitCredit.php
@@ -46,6 +46,7 @@ class BankDebitCredit implements ConverterInterface
             'a', // New style Rabobank (NL). Short for "Af"
             'dr', // https://old.reddit.com/r/FireflyIII/comments/bn2edf/generic_debitcredit_indicator/
             'af', // ING (NL).
+            'db', // Bank BCA (ID)
             'debet', // Triodos (NL)
             'debit', // ING (EN), thx Quibus!
             's', // Volksbank (DE), Short for "Soll"


### PR DESCRIPTION
In Bank BCA (indonesia), the statement uses DB for indicating Debit and CR for Credit

<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
Sorry for the wrong target branch in prev PR, it seems cannot be changed so I recreated it.

Changes in this pull request:

- add "db" as one of debit/negative generic indicator


@JC5
