### PR TITLE
Auto import: Honor JSON_CONFIGURATION_DIR

### DIFF
--- a/app/Console/AutoImports.php
+++ b/app/Console/AutoImports.php
@@ -48,6 +48,7 @@ use GrumpyDictator\FFIIIApiSupport\Model\Account as LocalAccount;
 use GrumpyDictator\FFIIIApiSupport\Request\GetAccountRequest;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * Trait AutoImports
@@ -138,6 +139,9 @@ trait AutoImports
 
         if (file_exists($fullJson)) {
             return $fullJson;
+        }
+        if (Storage::disk('configurations')->exists($jsonFile)){
+            return Storage::disk('configurations')->path($jsonFile);
         }
         $fallbackConfig = $this->getFallbackConfig($directory);
         if ($fallbackConfig) {


### PR DESCRIPTION
This PR fixes issue # (if relevant).
Fixes: https://github.com/firefly-iii/firefly-iii/issues/10026

Changes in this pull request:
- AutoImports Trait: restructure file finding & verification Make it More extensible and only verify once
- AutoImports Trait: Honor JSON_CONFIGURATION_DIR for AutoImports

Lightly Tested.

I would like to extend this to the single import command & and the post endpoint, but that would be a breaking change as now they expect a `$jsonFile, ?string $importableFile)`, and it would need to be `$jsonOrImportableFile, ?string $JsonFile)`

@JC5
