### PR TITLE
Consider account number uniquely identifying

### DIFF
--- a/app/Services/CSV/Conversion/Task/Accounts.php
+++ b/app/Services/CSV/Conversion/Task/Accounts.php
@@ -362,6 +362,13 @@ class Accounts extends AbstractTask
             return $array;
         }
 
+        // Return ID or number if not null
+        if ('' !== (string) $array['number']) {
+            app('log')->debug('At least the array with account-info has some account number info, return that.', $array);
+
+            return $array;
+        }
+
         // if the default account is not NULL, return that one instead:
         if (null !== $defaultAccount) {
             $default = $defaultAccount->toArray();


### PR DESCRIPTION
Fix firefly-iii/firefly-iii#10387

When `findAccount` is provided with a default, and the account does not exist in the database, only provided `id`, `iban` or `name` are considered before falling back to using the default account.

This change adds `number` to that list.