### PR TITLE
 This PR fixes issue 8296

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -228,6 +228,12 @@ VERIFY_TLS_SECURITY=true
 #
 JSON_CONFIGURATION_DIR=
 
+# 
+# Allow the matching of imported accounts to all accounts in firefly, aka disregard matching logic
+# This is helpful to work around edge cases for example when you have 
+# a single IBAN for multiple accounts that have differrent currencies
+ALLOW_ALL_ACCOUNT_SELECTION=false
+
 #
 # Time out when connecting with Firefly III.
 # π*10 seconds is usually fine.

--- a/.env.example
+++ b/.env.example
@@ -228,12 +228,6 @@ VERIFY_TLS_SECURITY=true
 #
 JSON_CONFIGURATION_DIR=
 
-# 
-# Allow the matching of imported accounts to all accounts in firefly, aka disregard matching logic
-# This is helpful to work around edge cases for example when you have 
-# a single IBAN for multiple accounts that have differrent currencies
-ALLOW_ALL_ACCOUNT_SELECTION=false
-
 #
 # Time out when connecting with Firefly III.
 # π*10 seconds is usually fine.

--- a/app/Services/Nordigen/Model/Transaction.php
+++ b/app/Services/Nordigen/Model/Transaction.php
@@ -447,8 +447,8 @@ class Transaction
     {
         $info = [];
         
-        // Add exchange rate if available
-        if (isset($this->currencyExchange['exchangeRate'])) {
+        // Add exchange rate if available and not zero
+        if (isset($this->currencyExchange['exchangeRate']) && $this->currencyExchange['exchangeRate'] != 0) {
             $info[] = sprintf('- Exchange rate: %s', $this->currencyExchange['exchangeRate']);
         }
         

--- a/app/Services/Nordigen/Model/Transaction.php
+++ b/app/Services/Nordigen/Model/Transaction.php
@@ -427,14 +427,9 @@ class Transaction
         }
 
         // Add currency exchange information if available
-        if (!empty($this->currencyExchange)) {
+        if (count($this->currencyExchange) > 0) {
             $exchangeInfo = $this->formatCurrencyExchangeInfo();
-            if ('' !== $exchangeInfo) {
-                if ('' !== $notes) {
-                    $notes .= "\n\n";
-                }
-                $notes .= $exchangeInfo;
-            }
+            $notes = trim(sprintf("%s\n\n%s", $notes, $exchangeInfo));
         }
 
         // room for other fields
@@ -450,20 +445,16 @@ class Transaction
      */
     private function formatCurrencyExchangeInfo(): string
     {
-        if (empty($this->currencyExchange)) {
-            return '';
-        }
-
         $info = [];
         
         // Add exchange rate if available
         if (isset($this->currencyExchange['exchangeRate'])) {
-            $info[] = sprintf('Exchange Rate: %s', $this->currencyExchange['exchangeRate']);
+            $info[] = sprintf('- Exchange rate: %s', $this->currencyExchange['exchangeRate']);
         }
         
         // Add source and target currencies if available
         if (isset($this->currencyExchange['sourceCurrency']) && isset($this->currencyExchange['targetCurrency'])) {
-            $info[] = sprintf('Currency Exchange: %s → %s', 
+            $info[] = sprintf('- Currency exchange: %s → %s', 
                 $this->currencyExchange['sourceCurrency'], 
                 $this->currencyExchange['targetCurrency']
             );


### PR DESCRIPTION
 This PR fixes issue https://github.com/firefly-iii/firefly-iii/issues/8296

Changes in this pull request:

- Add currency exchange data to the notes of the transaction
- When the IBAN matches an account we just put it on the top of the list.

### Additional notes:
I admit this might need two PRs or the very least tracked separately, but the reason I opened it like this is because without these changes I just can't test it.

So the problem is that right now on develop there is an account matching logic that does not allow me to select another account other then what is being matched by the IBAN.

Do please provide feedback/guidance on how you think that issue should be solved.


The other part of the PR in `app/Services/Nordigen/Model/Transaction.php` is just actually putting the data into the note. With these changes I can now implement webhook to handle converting the transaction to transfer and update the currency information.

