### PR TITLE
handle 0 exchange rate better https://github.com/firefly-iii/firefly-iii/issues/10609

### DIFF
--- a/app/Services/Nordigen/Model/Transaction.php
+++ b/app/Services/Nordigen/Model/Transaction.php
@@ -449,7 +449,7 @@ class Transaction
         $info = [];
 
         // Add exchange rate if available and not zero
-        if (isset($this->currencyExchange['exchangeRate']) && 0 !== $this->currencyExchange['exchangeRate']) {
+        if (isset($this->currencyExchange['exchangeRate']) && (float)$this->currencyExchange['exchangeRate'] != 0.0) {
             $info[] = sprintf('- Exchange rate: %s', $this->currencyExchange['exchangeRate']);
         }
 


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue https://github.com/firefly-iii/firefly-iii/issues/10609
Changes in this pull request:

This issue was introduced in https://github.com/firefly-iii/firefly-iii/issues/8296

Looks like some banks report things like:

```
                "currencyExchange": {
                    "sourceCurrency": "HUF",
                    "exchangeRate": "0"
                },
```

So we need to filter out these so they don't get added to the transaction note.

<img width="1096" height="202" alt="Image" src="https://github.com/user-attachments/assets/dbb398a7-c13b-41c4-8de5-d4882c503556" />

I thought the solution I added in a previous PR handled this, but apparently not if the value is a string.

I am still not super sure if this really fixes all the issues, so any input on the code is much appreciated.
