### PR TITLE
#10643: The amount modifier might be an integer at this point, in ord…

### DIFF
--- a/app/Services/CSV/Conversion/Task/Amount.php
+++ b/app/Services/CSV/Conversion/Task/Amount.php
@@ -84,13 +84,13 @@ class Amount extends AbstractTask
             return $transaction;
         }
         // modify amount:
-        $amount                = bcmul($amount, $transaction['amount_modifier']);
+        $amount = bcmul($amount, (string)$transaction['amount_modifier']);
 
         Log::debug(sprintf('Amount is now %s.', $amount));
 
         // modify foreign amount
         if (array_key_exists('foreign_amount', $transaction)) {
-            $transaction['foreign_amount'] = bcmul($transaction['foreign_amount'], $transaction['amount_modifier']);
+            $transaction['foreign_amount'] = bcmul($transaction['foreign_amount'], (string) $transaction['amount_modifier']);
             Log::debug(sprintf('FOREIGN amount is now %s.', $transaction['foreign_amount']));
         }
 


### PR DESCRIPTION
…er to not distress bcmul make it a string.

<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue # 10643

Changes in this pull request:

- bcmul in PHP requires all the variables to be a string when the strict values are on, when it becomes an integer it will fail
