### PR TITLE
Add OUT as debit indicator

### DIFF
--- a/app/Services/CSV/Converter/BankDebitCredit.php
+++ b/app/Services/CSV/Converter/BankDebitCredit.php
@@ -52,6 +52,7 @@ class BankDebitCredit implements ConverterInterface
             'dbit', // https://subsembly.com/index.html (Banking4 App)
             'charge', // not sure which bank but it's insane.
             '(-)', // Banco Bolivariano in Ecuador (same opinion as above)
+            'out', // Wise
         ];
 
         // Lowercase the value and trim it for comparison.


### PR DESCRIPTION
Wise uses `IN` and `OUT` as credit/debit indicators

Changes in this pull request:

- Add `out` to the list of debit indicators
