### PR TITLE
Update fontawesome imports

### DIFF
--- a/resources/js/v2/src/sass/app.scss
+++ b/resources/js/v2/src/sass/app.scss
@@ -18,6 +18,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+// Font awesome
+@use '@fortawesome/fontawesome-free/scss/variables' with (
+  $font-path: "@fortawesome/fontawesome-free/webfonts",
+);
+@use '@fortawesome/fontawesome-free/scss/fontawesome';
+@use '@fortawesome/fontawesome-free/scss/fa' as fa;
+@use '@fortawesome/fontawesome-free/scss/regular.scss' as fa-regular;
+@use '@fortawesome/fontawesome-free/scss/solid.scss' as fa-solid;
+@use '@fortawesome/fontawesome-free/scss/brands.scss' as fa-brands;
+
+// Configuration
 $color-mode-type: media-query;
 $link-decoration: none !default;
 $font-family-sans-serif: "Roboto", sans-serif;
@@ -69,12 +80,3 @@ td:not(:hover) .hidden-edit-button {
     visibility: hidden;
 }
 
-
-
-// Font awesome
-//@import "~font-awesome/css/font-awesome";
-$fa-font-path: "@fortawesome/fontawesome-free/webfonts";
-@import "@fortawesome/fontawesome-free/scss/fontawesome.scss";
-@import "@fortawesome/fontawesome-free/scss/solid.scss";
-@import "@fortawesome/fontawesome-free/scss/brands.scss";
-@import "@fortawesome/fontawesome-free/scss/regular.scss";


### PR DESCRIPTION
in an attempt to update the fontawesome usage from v6 to v7, remove `@import` references and add `@use` references
    
This PR implements changes referenced in issue https://github.com/firefly-iii/firefly-iii/issues/11000

Changes in this pull request:
ref: https://docs.fontawesome.com/upgrade/scss#3-update-your-compiles-syntax-for-v7

- remove `@import`s for fontawesome
- add `@use` for fontawesome
