### PR TITLE
fix(enable-banking): use UID instead of identification hash for accou…

### DIFF
--- a/app/Services/Shared/Conversion/CreatesAccounts.php
+++ b/app/Services/Shared/Conversion/CreatesAccounts.php
@@ -74,7 +74,7 @@ trait CreatesAccounts
                 return $entry->getIdentifier() === $importServiceId;
             }
             if ($entry instanceof EnableBankingAccount) {
-                return $entry->getIdentificationHash() === $importServiceId;
+                return $entry->getUid() === $importServiceId;
             }
             Log::debug(sprintf('Class of existing entry is %s', $entry::class));
 

--- a/app/Services/Shared/Model/ImportServiceAccount.php
+++ b/app/Services/Shared/Model/ImportServiceAccount.php
@@ -126,10 +126,10 @@ final class ImportServiceAccount
                 Log::debug(sprintf('IBAN "%s" is invalid so it will be ignored.', $iban));
                 $iban = '';
             }
-            Log::debug(sprintf('Generate EB ImportServiceAccount with ID %s', $account->getIdentificationHash()));
+            Log::debug(sprintf('Generate EB ImportServiceAccount with ID %s', $account->getUid()));
 
             return self::fromArray([
-                'id'            => $account->getIdentificationHash(),
+                'id'            => $account->getUid(),
                 'name'          => $account->getFullName(),
                 'currency_code' => $account->getCurrency(),
                 'iban'          => $iban,
@@ -349,7 +349,7 @@ final class ImportServiceAccount
             }
 
             $current  = self::fromArray([
-                'id'            => $account->getIdentificationHash(),
+                'id'            => $account->getUid(),
                 'name'          => $account->getFullName(),
                 'currency_code' => $account->getCurrency(),
                 'iban'          => $iban,


### PR DESCRIPTION
**Reference issues and PRs**

Fixes #12151.

**What does this implement/fix? Explain your changes.**

This PR fixes Enable Banking transaction imports failing with 422 WRONG_REQUEST_PARAMETERS.

The importer was using the Enable Banking account identification_hash as the account identifier passed through the import pipeline and ultimately used for the transactions API call. The Enable Banking transactions endpoint expects the account uid (UUID). When the hash is used, the API rejects the request with an “Invalid value” for account_id.

**Changes:**

app/Services/Shared/Model/ImportServiceAccount.php
For EnableBankingAccount, use $account->getUid() as the ImportServiceAccount id (instead of getIdentificationHash()), both in convertSingleAccount() and convertEnableBankingArray().
app/Services/Shared/Conversion/CreatesAccounts.php
Update the Enable Banking matching branch to compare using $entry->getUid() so the account lookup remains consistent with the updated identifier.

**Result:**

Enable Banking transaction fetching works again.
Account matching/creation remains consistent using the same provider identifier.

**Tested on:**

Data Importer v2.2.3
Enable Banking (ING)

**AI usage disclosure**

I used AI assistance for:

 Code generation (e.g., when writing an implementation or fixing a bug)
 Documentation (including examples)
 Research and understanding

**Any other comments?**

None.