### PR TITLE
feat: add skip first and last lines options for CSV import

### DIFF
--- a/app/Http/Request/ConfigurationPostRequest.php
+++ b/app/Http/Request/ConfigurationPostRequest.php
@@ -85,6 +85,8 @@ final class ConfigurationPostRequest extends Request
             'ignore_duplicate_lines'        => $this->convertBoolean($this->get('ignore_duplicate_lines')),
             'ignore_duplicate_transactions' => $this->convertBoolean($this->get('ignore_duplicate_transactions')),
             'skip_form'                     => $this->convertBoolean($this->get('skip_form')),
+            'skip_first_lines'              => $this->convertToInteger('skip_first_lines'),
+            'skip_last_lines'               => $this->convertToInteger('skip_last_lines'),
             'add_import_tag'                => $this->convertBoolean($this->get('add_import_tag')),
             'pending_transactions'          => $this->convertBoolean($this->get('pending_transactions')),
             'custom_tag'                    => $this->convertToString('custom_tag'),
@@ -194,6 +196,8 @@ final class ConfigurationPostRequest extends Request
             'ignore_duplicate_lines'        => 'numeric|between:0,1',
             'ignore_duplicate_transactions' => 'numeric|between:0,1',
             'skip_form'                     => 'numeric|between:0,1',
+            'skip_first_lines'              => 'nullable|integer|min:0',
+            'skip_last_lines'               => 'nullable|integer|min:0',
             'add_import_tag'                => 'numeric|between:0,1',
             'ignore_spectre_categories'     => 'numeric|between:0,1',
 

--- a/app/Services/CSV/Conversion/Routine/CSVFileProcessor.php
+++ b/app/Services/CSV/Conversion/Routine/CSVFileProcessor.php
@@ -41,6 +41,8 @@ final class CSVFileProcessor
 {
     private string $delimiter;
     private bool $hasHeaders;
+    private int $skipFirstLines = 0;
+    private int $skipLastLines = 0;
     private Reader $reader;
     private ImportJob $importJob;
     private Configuration $configuration;
@@ -61,7 +63,16 @@ final class CSVFileProcessor
     public function processCSVFile(): array
     {
         Log::debug(sprintf('[%s] Now in %s', config('importer.version'), __METHOD__));
-        $offset = $this->hasHeaders ? 1 : 0;
+
+        // Calculate total offset: skip_first_lines + (1 if headers)
+        $offset = $this->skipFirstLines + ($this->hasHeaders ? 1 : 0);
+
+        Log::debug(sprintf(
+            'Skip first lines: %d, Has headers: %s, Total offset: %d',
+            $this->skipFirstLines,
+            $this->hasHeaders ? 'yes' : 'no',
+            $offset
+        ));
 
         try {
             $this->reader->setDelimiter($this->delimiter);
@@ -108,6 +119,16 @@ final class CSVFileProcessor
         $this->delimiter = $map[$delimiter] ?? ',';
     }
 
+    public function setSkipFirstLines(int $lines): void
+    {
+        $this->skipFirstLines = $lines;
+    }
+
+    public function setSkipLastLines(int $lines): void
+    {
+        $this->skipLastLines = $lines;
+    }
+
     /**
      * Loop all records from CSV file.
      *
@@ -118,15 +139,44 @@ final class CSVFileProcessor
         $updatedRecords = [];
         $count          = $records->count();
         Log::info(sprintf('Now in %s with %d records', __METHOD__, $count));
+
+        // Calculate how many lines to actually process
+        $linesToProcess = $this->skipLastLines > 0
+            ? $count - $this->skipLastLines
+            : $count;
+
+        Log::debug(sprintf(
+            'Total records: %d, Skip last lines: %d, Lines to process: %d',
+            $count,
+            $this->skipLastLines,
+            $linesToProcess
+        ));
+
         $currentIndex   = 1;
         foreach ($records as $line) {
+            // Stop processing if we've reached the lines to skip at the end
+            if ($currentIndex > $linesToProcess) {
+                Log::debug(sprintf(
+                    'Skipping line %d/%d (part of last %d lines)',
+                    $currentIndex,
+                    $count,
+                    $this->skipLastLines
+                ));
+                ++$currentIndex;
+                continue;
+            }
+
             $line             = $this->sanitize($line);
-            Log::debug(sprintf('Parsing line %d/%d', $currentIndex, $count));
+            Log::debug(sprintf('Parsing line %d/%d', $currentIndex, $linesToProcess));
             $updatedRecords[] = $line;
 
             ++$currentIndex;
         }
-        Log::info(sprintf('Parsed all %d lines.', $count));
+        Log::info(sprintf(
+            'Parsed %d lines (skipped last %d lines).',
+            count($updatedRecords),
+            $this->skipLastLines
+        ));
 
         // exclude double lines.
         if ($this->configuration->isIgnoreDuplicateLines()) {

--- a/app/Services/CSV/Conversion/RoutineManager.php
+++ b/app/Services/CSV/Conversion/RoutineManager.php
@@ -79,6 +79,8 @@ final class RoutineManager implements RoutineManagerInterface
         // convert CSV file into raw lines (arrays)
         $this->csvFileProcessor->setHasHeaders($this->configuration->isHeaders());
         $this->csvFileProcessor->setDelimiter($this->configuration->getDelimiter());
+        $this->csvFileProcessor->setSkipFirstLines($this->configuration->getSkipFirstLines());
+        $this->csvFileProcessor->setSkipLastLines($this->configuration->getSkipLastLines());
 
         $this->csvFileProcessor->setReader(FileReader::getReaderFromContent($this->importJob->getImportableFileString($this->configuration->isConversion())));
 

--- a/app/Services/CSV/Roles/RoleService.php
+++ b/app/Services/CSV/Roles/RoleService.php
@@ -76,11 +76,14 @@ final class RoleService
         }
 
         $headers   = [];
+        $skipFirstLines = $configuration->getSkipFirstLines();
+        
         if (true === $configuration->isHeaders()) {
             try {
+                // Skip first N lines, then read the header line
                 $stmt    = new Statement()
                     ->limit(1)
-                    ->offset(0)
+                    ->offset($skipFirstLines)
                 ;
                 $records = $stmt->process($reader);
                 $headers = $records->first();
@@ -98,9 +101,10 @@ final class RoleService
             Log::debug('Role service: file has no headers');
 
             try {
+                // Skip first N lines, then read the first data line to count columns
                 $stmt    = new Statement()
                     ->limit(1)
-                    ->offset(0)
+                    ->offset($skipFirstLines)
                 ;
                 $records = $stmt->process($reader);
                 $count   = count($records->first());
@@ -148,14 +152,46 @@ final class RoleService
                 break;
         }
 
-        $offset         = $configuration->isHeaders() ? 1 : 0;
+        $skipFirstLines = $configuration->getSkipFirstLines();
+        $skipLastLines  = $configuration->getSkipLastLines();
+        
+        // Calculate offset: skip_first_lines + (1 if headers)
+        $offset         = $skipFirstLines + ($configuration->isHeaders() ? 1 : 0);
         $examples       = [];
         $pseudoExamples = [];
+
+        // Calculate example limit: min(EXAMPLE_COUNT, total_rows - skip_first - skip_last - headers)
+        $exampleLimit   = self::EXAMPLE_COUNT;
+        
+        try {
+            // Count total rows in file
+            $totalRows = $reader->count();
+            
+            // Calculate available data rows: total - skip_first - skip_last - (1 if headers)
+            $availableRows = $totalRows - $skipFirstLines - $skipLastLines - ($configuration->isHeaders() ? 1 : 0);
+            
+            if ($availableRows > 0) {
+                $exampleLimit = min(self::EXAMPLE_COUNT, $availableRows);
+                Log::debug(sprintf('Total rows: %d, skip first: %d, skip last: %d, headers: %s, available: %d, example limit: %d',
+                    $totalRows, $skipFirstLines, $skipLastLines, $configuration->isHeaders() ? 'yes' : 'no', $availableRows, $exampleLimit
+                ));
+            } else {
+                // No data rows available
+                $exampleLimit = 0;
+                Log::warning(sprintf('No data rows available for examples: total=%d, skip_first=%d, skip_last=%d, headers=%s',
+                    $totalRows, $skipFirstLines, $skipLastLines, $configuration->isHeaders() ? 'yes' : 'no'
+                ));
+            }
+        } catch (Exception $e) {
+            Log::error(sprintf('[%s]: Error counting rows: %s', config('importer.version'), $e->getMessage()));
+            // Fall back to default behavior if counting fails
+            $exampleLimit = self::EXAMPLE_COUNT;
+        }
 
         // make statement.
         try {
             $stmt = new Statement()
-                ->limit(self::EXAMPLE_COUNT)
+                ->limit($exampleLimit)
                 ->offset($offset)
             ;
 

--- a/app/Services/Shared/Configuration/Configuration.php
+++ b/app/Services/Shared/Configuration/Configuration.php
@@ -69,6 +69,8 @@ final class Configuration
 
     // csv config
     private string $groupedTransactionHandling;
+    private int $skipFirstLines = 0;
+    private int $skipLastLines = 0;
 
     // spectre + nordigen configuration
     private bool $headers                 = false;
@@ -361,6 +363,8 @@ final class Configuration
         $object->date                        = $array['date'] ?? 'Y-m-d';
         $object->defaultAccount              = $array['default_account'] ?? 0;
         $object->delimiter                   = $delimiters[$array['delimiter'] ?? ','] ?? 'comma';
+        $object->skipFirstLines              = $array['skip_first_lines'] ?? 0;
+        $object->skipLastLines               = $array['skip_last_lines'] ?? 0;
         $object->rules                       = $array['rules'] ?? true;
         $object->webhooks                    = $array['webhooks'] ?? true;
         $object->skipForm                    = $array['skip_form'] ?? false;
@@ -717,6 +721,16 @@ final class Configuration
         return $this->delimiter;
     }
 
+    public function getSkipFirstLines(): int
+    {
+        return $this->skipFirstLines;
+    }
+
+    public function getSkipLastLines(): int
+    {
+        return $this->skipLastLines;
+    }
+
     public function getDoMapping(): array
     {
         return $this->doMapping;
@@ -1022,6 +1036,8 @@ final class Configuration
             'date'                         => $this->date,
             'default_account'              => $this->defaultAccount,
             'delimiter'                    => $this->delimiter,
+            'skip_first_lines'             => $this->skipFirstLines,
+            'skip_last_lines'              => $this->skipLastLines,
             'headers'                      => $this->headers,
             'rules'                        => $this->rules,
             'webhooks'                     => $this->webhooks,
@@ -1252,6 +1268,8 @@ final class Configuration
         $this->dateNotBefore               = (string) $request['date_not_before'];
         $this->dateNotAfter                = (string) $request['date_not_after'];
         $this->conversion                  = $request['conversion'];
+        $this->skipFirstLines              = $request['skip_first_lines'];
+        $this->skipLastLines               = $request['skip_last_lines'];
         $this->groupedTransactionHandling  = $request['grouped_transaction_handling'];
         $this->useEntireOpposingAddress    = $request['use_entire_opposing_address'];
         $this->newAccounts                 = $request['to_create'];

--- a/resources/views/v2/import/004-configure/partials/csv-options.blade.php
+++ b/resources/views/v2/import/004-configure/partials/csv-options.blade.php
@@ -95,6 +95,40 @@
                     </div>
                 </div>
 
+                <div class="form-group row mb-3">
+                    <label for="skip_first_lines" class="col-sm-3 col-form-label">Skip first lines</label>
+                    <div class="col-sm-9">
+                        <input type="number"
+                            name="skip_first_lines"
+                            id="skip_first_lines"
+                            class="form-control"
+                            min="0"
+                            value="{{ $configuration->getSkipFirstLines() ?? 0 }}"
+                            aria-describedby="skipFirstLinesHelp">
+                        <small id="skipFirstLinesHelp" class="form-text text-muted">
+                            Number of lines to skip at the beginning of the file (before processing headers or data).
+                            Useful for files with additional rows at the top.
+                        </small>
+                    </div>
+                </div>
+
+                <div class="form-group row mb-3">
+                    <label for="skip_last_lines" class="col-sm-3 col-form-label">Skip last lines</label>
+                    <div class="col-sm-9">
+                        <input type="number"
+                            name="skip_last_lines"
+                            id="skip_last_lines"
+                            class="form-control"
+                            min="0"
+                            value="{{ $configuration->getSkipLastLines() ?? 0 }}"
+                            aria-describedby="skipLastLinesHelp">
+                        <small id="skipLastLinesHelp" class="form-text text-muted">
+                            Number of lines to skip at the end of the file.
+                            Useful for files with additional rows at the bottom.
+                        </small>
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
Partially implements https://github.com/firefly-iii/firefly-iii/issues/5789 :

- **skiprows**: Line numbers to skip (0-indexed) or number of lines to skip (int) at the start of the file.
- **skipfooterint**: Number of lines at bottom of file to skip.

AFAIK there is no existing test setup for data importer, so tests are omitted.

@JC5 thanks for maintaining firefly!