### PR TITLE
Add autoimport progress status endpoint

### DIFF
--- a/app/Console/AutoImports.php
+++ b/app/Console/AutoImports.php
@@ -42,6 +42,7 @@ use GrumpyDictator\FFIIIApiSupport\Exceptions\ApiHttpException;
 use GrumpyDictator\FFIIIApiSupport\Model\Account as LocalAccount;
 use GrumpyDictator\FFIIIApiSupport\Request\GetAccountRequest;
 use GrumpyDictator\FFIIIApiSupport\Response\GetAccountResponse;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -175,9 +176,15 @@ trait AutoImports
     private function importFiles(string $directory, array $files): array
     {
         $exitCodes = [];
+        $total     = array_sum(array_map('count', $files));
+        $current   = 0;
+        $this->saveAutoImportProgress('running', $current, $total, null, []);
 
         foreach ($files as $jsonFile => $importableFiles) {
             foreach ($importableFiles as $importableFile) {
+                ++$current;
+                $this->saveAutoImportProgress('running', $current, $total, basename($importableFile), $exitCodes);
+
                 try {
                     $exitCodes[$importableFile] = $this->importFileAsImportJob($jsonFile, $importableFile);
                 } catch (ImporterErrorException $e) {
@@ -187,9 +194,27 @@ trait AutoImports
                 }
             }
         }
+        $this->saveAutoImportProgress('done', $current, $total, null, $exitCodes);
         Log::debug(sprintf('Collection of exit codes: %s', implode(', ', array_values($exitCodes))));
 
         return $exitCodes;
+    }
+
+    private function saveAutoImportProgress(string $status, int $current, int $total, ?string $currentFile, array $exitCodes): void
+    {
+        // keep file paths out of the response, only expose base names.
+        $codes = [];
+        foreach ($exitCodes as $file => $code) {
+            $codes[basename((string) $file)] = $code;
+        }
+        Cache::put('autoimport-status', [
+            'status'       => $status,
+            'current'      => $current,
+            'total'        => $total,
+            'current_file' => $currentFile,
+            'exit_codes'   => $codes,
+            'updated_at'   => Carbon::now()->toIso8601String(),
+        ], 86400);
     }
 
     /**

--- a/app/Http/Controllers/AutoImportController.php
+++ b/app/Http/Controllers/AutoImportController.php
@@ -28,9 +28,9 @@ use App\Console\AutoImports;
 use App\Console\HaveAccess;
 use App\Console\VerifyJSON;
 use App\Exceptions\ImporterErrorException;
+use App\Http\Request\AutoImportRequest;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
@@ -43,10 +43,8 @@ final class AutoImportController extends Controller
     /**
      * @throws ImporterErrorException
      */
-    public function index(Request $request): JsonResponse
+    public function index(AutoImportRequest $request): JsonResponse
     {
-        $this->validateRequest($request);
-
         $argument     = (string) ($request->input('directory') ?? './');
         $directory    = realpath($argument);
         if (false === $directory) {
@@ -82,35 +80,14 @@ final class AutoImportController extends Controller
         return response()->json(['message' => 'Seems to have worked!']);
     }
 
-    /**
-     * @throws ImporterErrorException
-     */
-    public function status(Request $request): JsonResponse
+    public function status(AutoImportRequest $request): JsonResponse
     {
-        $this->validateRequest($request);
-
         $status = Cache::get('autoimport-status');
         if (!is_array($status)) {
             return response()->json(['status' => 'unknown']);
         }
 
         return response()->json($status);
-    }
-
-    /**
-     * @throws ImporterErrorException
-     */
-    private function validateRequest(Request $request): void
-    {
-        if (false === config('importer.can_post_autoimport')) {
-            throw new ImporterErrorException('Please set CAN_POST_AUTOIMPORT=true for this function to work.');
-        }
-
-        $secret       = (string) ($request->input('secret') ?? '');
-        $systemSecret = (string) config('importer.auto_import_secret');
-        if ('' === $secret || '' === $systemSecret || !hash_equals($secret, (string) config('importer.auto_import_secret')) || strlen($systemSecret) < 16) {
-            throw new ImporterErrorException('Please make sure your secret value matches whatever is in AUTO_IMPORT_SECRET.');
-        }
     }
 
     public function info(mixed $string): void

--- a/app/Http/Controllers/AutoImportController.php
+++ b/app/Http/Controllers/AutoImportController.php
@@ -31,6 +31,7 @@ use App\Exceptions\ImporterErrorException;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 final class AutoImportController extends Controller
@@ -44,15 +45,7 @@ final class AutoImportController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        if (false === config('importer.can_post_autoimport')) {
-            throw new ImporterErrorException('Please set CAN_POST_AUTOIMPORT=true for this function to work.');
-        }
-
-        $secret       = (string) ($request->input('secret') ?? '');
-        $systemSecret = (string) config('importer.auto_import_secret');
-        if ('' === $secret || '' === $systemSecret || !hash_equals($secret, (string) config('importer.auto_import_secret')) || strlen($systemSecret) < 16) {
-            throw new ImporterErrorException('Please make sure your secret value matches whatever is in AUTO_IMPORT_SECRET.');
-        }
+        $this->validateRequest($request);
 
         $argument     = (string) ($request->input('directory') ?? './');
         $directory    = realpath($argument);
@@ -87,6 +80,37 @@ final class AutoImportController extends Controller
         }
 
         return response()->json(['message' => 'Seems to have worked!']);
+    }
+
+    /**
+     * @throws ImporterErrorException
+     */
+    public function status(Request $request): JsonResponse
+    {
+        $this->validateRequest($request);
+
+        $status = Cache::get('autoimport-status');
+        if (!is_array($status)) {
+            return response()->json(['status' => 'unknown']);
+        }
+
+        return response()->json($status);
+    }
+
+    /**
+     * @throws ImporterErrorException
+     */
+    private function validateRequest(Request $request): void
+    {
+        if (false === config('importer.can_post_autoimport')) {
+            throw new ImporterErrorException('Please set CAN_POST_AUTOIMPORT=true for this function to work.');
+        }
+
+        $secret       = (string) ($request->input('secret') ?? '');
+        $systemSecret = (string) config('importer.auto_import_secret');
+        if ('' === $secret || '' === $systemSecret || !hash_equals($secret, (string) config('importer.auto_import_secret')) || strlen($systemSecret) < 16) {
+            throw new ImporterErrorException('Please make sure your secret value matches whatever is in AUTO_IMPORT_SECRET.');
+        }
     }
 
     public function info(mixed $string): void

--- a/app/Http/Request/AutoImportRequest.php
+++ b/app/Http/Request/AutoImportRequest.php
@@ -24,21 +24,36 @@ declare(strict_types=1);
 
 namespace App\Http\Request;
 
+use Illuminate\Support\Facades\Log;
+
 final class AutoImportRequest extends Request
 {
     /**
      * Verify the request: the feature must be enabled and the secret must match.
+     * The response is a plain 403 on purpose; details only go to the log.
      */
     public function authorize(): bool
     {
         if (false === config('importer.can_post_autoimport')) {
+            Log::warning('Denied autoimport request: CAN_POST_AUTOIMPORT is not enabled.');
+
             return false;
         }
 
         $secret       = (string) ($this->input('secret') ?? '');
         $systemSecret = (string) config('importer.auto_import_secret');
+        if ('' === $systemSecret || strlen($systemSecret) < 16) {
+            Log::warning('Denied autoimport request: AUTO_IMPORT_SECRET is not set or shorter than 16 characters.');
 
-        return '' !== $secret && '' !== $systemSecret && strlen($systemSecret) >= 16 && hash_equals($systemSecret, $secret);
+            return false;
+        }
+        if ('' === $secret || !hash_equals($systemSecret, $secret)) {
+            Log::warning('Denied autoimport request: submitted secret does not match AUTO_IMPORT_SECRET.');
+
+            return false;
+        }
+
+        return true;
     }
 
     public function rules(): array

--- a/app/Http/Request/AutoImportRequest.php
+++ b/app/Http/Request/AutoImportRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * AutoImportRequest.php
+ * Copyright (c) 2025 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Http\Request;
+
+final class AutoImportRequest extends Request
+{
+    /**
+     * Verify the request: the feature must be enabled and the secret must match.
+     */
+    public function authorize(): bool
+    {
+        if (false === config('importer.can_post_autoimport')) {
+            return false;
+        }
+
+        $secret       = (string) ($this->input('secret') ?? '');
+        $systemSecret = (string) config('importer.auto_import_secret');
+
+        return '' !== $secret && '' !== $systemSecret && strlen($systemSecret) >= 16 && hash_equals($systemSecret, $secret);
+    }
+
+    public function rules(): array
+    {
+        return ['directory' => 'string', 'secret' => 'required|string'];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 // import by POST
 Route::post('/autoimport', 'AutoImportController@index')->name('autoimport');
+Route::get('/autoimport/status', 'AutoImportController@status')->name('autoimport.status');
 Route::post('/autoupload', 'AutoUploadController@index')->name('autoupload');
 
 // new routes that use less session data and redirects.


### PR DESCRIPTION
## Summary

Implements the progress/status API requested in firefly-iii/firefly-iii#12101.

- `importFiles()` (shared by the console `autoimport` command and `POST /autoimport`) now records progress in the cache: status (`running`/`done`), current file index, total file count, current file name, per-file exit codes and a timestamp.
- New `GET /autoimport/status` endpoint returns that progress as JSON. It is guarded by the same `CAN_POST_AUTOIMPORT` + `AUTO_IMPORT_SECRET` checks as `POST /autoimport` (guard extracted into a shared method).
- Only base names of files are exposed, never full paths.

Example while an import is running:

```json
{
  "status": "running",
  "current": 2,
  "total": 5,
  "current_file": "transactions.csv",
  "exit_codes": {"other.csv": 0},
  "updated_at": "2026-07-02T10:00:00+00:00"
}
```

Returns `{"status": "unknown"}` when no import has run yet.

Custom UIs can poll this endpoint while the (still synchronous) `POST /autoimport` call is in flight.