### PR TITLE
Fix fatal error when the Enable Banking private key path is a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /vendor
 .env
 .env.backup
+.phpunit.cache
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml

--- a/app/Services/EnableBanking/Authentication/SecretManager.php
+++ b/app/Services/EnableBanking/Authentication/SecretManager.php
@@ -92,11 +92,33 @@ final class SecretManager
         if ('' === $sessionKey) {
             Log::debug('No Enable Banking private key in session, will return config variable!');
             $privateKey = (string) config('eb.private_key');
+            if ('' === $privateKey) {
+                Log::error('The Enable Banking private key in the configuration is empty! Did you set ENABLE_BANKING_PRIVATE_KEY?');
+
+                return '';
+            }
 
             // see if this is a file that exists and is readable.
-            if (false !== realpath($privateKey) && file_exists(realpath($privateKey)) && is_readable(realpath($privateKey))) {
+            $path       = realpath($privateKey);
+            if (false !== $path && file_exists($path)) {
+                // mind you: file_exists() and is_readable() are also true for directories. A broken
+                // volume mount can leave a directory where the key file should be, and reading that
+                // is a fatal error. So explicitly demand a readable *file* here.
+                if (!is_file($path) || !is_readable($path)) {
+                    Log::error(sprintf('The Enable Banking private key "%s" is not a readable file. Is it a directory, or are the permissions wrong?', $path));
+
+                    return '';
+                }
                 Log::debug('Enable Banking private key is a file, will try to read it.');
-                $privateKey = file_get_contents(realpath($privateKey));
+                $content = file_get_contents($path);
+                if (false === $content) {
+                    Log::error(sprintf('Could not read the Enable Banking private key from "%s".', $path));
+
+                    return '';
+                }
+                // trim it: a trailing newline (which most editors add) would keep the key from
+                // being recognised as base64, and it would be returned unwrapped and unusable.
+                $privateKey = trim($content);
             }
 
             if (self::isBase64($privateKey)) {

--- a/tests/Unit/Services/EnableBanking/Authentication/SecretManagerTest.php
+++ b/tests/Unit/Services/EnableBanking/Authentication/SecretManagerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * SecretManagerTest.php
+ * Copyright (c) 2026 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\EnableBanking\Authentication;
+
+use App\Services\EnableBanking\Authentication\SecretManager;
+use Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \App\Services\EnableBanking\Authentication\SecretManager
+ */
+final class SecretManagerTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir().'/eb-secret-manager-'.bin2hex(random_bytes(8));
+        mkdir($this->tempDir);
+        session()->forget(SecretManager::EB_PRIVATE_KEY);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ((array) glob($this->tempDir.'/*') as $file) {
+            if (is_file((string) $file)) {
+                unlink((string) $file);
+            }
+            if (is_dir((string) $file)) {
+                rmdir((string) $file);
+            }
+        }
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * A misconfigured Docker/Kubernetes volume mount can turn the private key path into a
+     * directory. Reading it must not blow up, see issue #12493.
+     */
+    public function testPrivateKeyPathIsDirectory(): void
+    {
+        $directory = $this->tempDir.'/key.pem';
+        mkdir($directory);
+        config(['eb.private_key' => $directory]);
+
+        self::assertSame('', SecretManager::getPrivateKey());
+        self::assertFalse(SecretManager::hasPrivateKeyAvailable());
+    }
+
+    /**
+     * A path that exists but cannot be read must not be mistaken for the key itself.
+     */
+    public function testPrivateKeyFileIsNotReadable(): void
+    {
+        $file = $this->tempDir.'/unreadable.pem';
+        file_put_contents($file, "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----");
+        chmod($file, 0000);
+        if (is_readable($file)) {
+            // running as root, permissions are not enforced.
+            self::markTestSkipped('Cannot make a file unreadable as this user.');
+        }
+        config(['eb.private_key' => $file]);
+
+        self::assertSame('', SecretManager::getPrivateKey());
+    }
+
+    public function testPrivateKeyIsPemFile(): void
+    {
+        $pem  = sprintf("-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----", base64_encode('not-a-real-key'));
+        $file = $this->tempDir.'/key.pem';
+        file_put_contents($file, $pem);
+        config(['eb.private_key' => $file]);
+
+        self::assertSame($pem, SecretManager::getPrivateKey());
+    }
+
+    public function testPrivateKeyIsBase64File(): void
+    {
+        $base64 = base64_encode(str_repeat('this-is-not-a-real-key', 10));
+        $file   = $this->tempDir.'/key.b64';
+        file_put_contents($file, $base64);
+        config(['eb.private_key' => $file]);
+
+        $expected = sprintf("-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----", implode("\n", str_split($base64, 64)));
+        self::assertSame($expected, SecretManager::getPrivateKey());
+    }
+
+    /**
+     * Almost every editor and every `echo` leaves a trailing newline behind. That newline must not
+     * stop the key from being recognised as base64.
+     */
+    public function testPrivateKeyIsBase64FileWithTrailingNewline(): void
+    {
+        $base64 = base64_encode(str_repeat('this-is-not-a-real-key', 10));
+        $file   = $this->tempDir.'/key.b64';
+        file_put_contents($file, $base64."\n");
+        config(['eb.private_key' => $file]);
+
+        $expected = sprintf("-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----", implode("\n", str_split($base64, 64)));
+        self::assertSame($expected, SecretManager::getPrivateKey());
+    }
+
+    public function testPrivateKeyIsPemFileWithTrailingNewline(): void
+    {
+        $pem  = sprintf("-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----", base64_encode('not-a-real-key'));
+        $file = $this->tempDir.'/key.pem';
+        file_put_contents($file, $pem."\n");
+        config(['eb.private_key' => $file]);
+
+        self::assertSame($pem, SecretManager::getPrivateKey());
+    }
+
+    public function testPrivateKeyIsInlinePem(): void
+    {
+        $pem = sprintf("-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----", base64_encode('not-a-real-key'));
+        config(['eb.private_key' => $pem]);
+
+        self::assertSame($pem, SecretManager::getPrivateKey());
+    }
+
+    public function testPrivateKeyIsEmpty(): void
+    {
+        config(['eb.private_key' => '']);
+
+        self::assertSame('', SecretManager::getPrivateKey());
+        self::assertFalse(SecretManager::hasPrivateKeyAvailable());
+    }
+
+    public function testSessionPrivateKeyWins(): void
+    {
+        config(['eb.private_key' => $this->tempDir]);
+        SecretManager::savePrivateKey('key-from-session');
+
+        self::assertSame('key-from-session', SecretManager::getPrivateKey());
+    }
+}


### PR DESCRIPTION
#### Reference issues and PRs

Fixes firefly-iii/firefly-iii#12493

#### What does this implement/fix? Explain your changes.

`SecretManager::getPrivateKey()` called `file_get_contents()` on the private key path after
checking only `file_exists()` and `is_readable()`. Both of those return `true` for directories,
so when a volume mount leaves a directory where the key file should be, the importer dies with
`file_get_contents(): errno=21 Is a directory`.

The change makes the file branch demand a readable *file*, and handles the two other ways this
code could silently produce a broken key:

* empty `eb.private_key` → log an error naming `ENABLE_BANKING_PRIVATE_KEY`, return `''`
* path exists but is a directory or unreadable → log an error, return `''`
* `file_get_contents()` returns `false` → log an error, return `''`

It also `trim()`s the file contents. A trailing newline — which most editors and every `echo >`
add — made `isBase64()` fail, so a perfectly good base64 key was returned unwrapped and was
unusable further down. That was the second half of the reporter's problem.

Behaviour on a correct configuration is unchanged; `hasPrivateKeyAvailable()` now correctly
reports `false` for all of the broken cases above instead of `true`.

Two notes, both easy to drop if you'd rather not have them:

* I added `tests/Unit/Services/EnableBanking/Authentication/SecretManagerTest.php` covering the
  directory case, the unreadable case, PEM/base64 files with and without a trailing newline, the
  inline-PEM case, the empty case, and session precedence. The 9 tests pass on PHP 8.5 (1 skips
  when run as root, since root ignores file permissions). The pre-existing errors in
  `AmountTest`, `ConfigurationContractValidatorTest` and `DemoModeTest` are untouched by this
  change and were already failing on `develop` for me.
* Second commit is a one-liner adding `.phpunit.cache` to `.gitignore`; `phpunit.xml` sets
  `cacheDirectory=".phpunit.cache"` but only the old `.phpunit.result.cache` file was ignored.

The production change is 24 added / 2 removed lines, so it is just over the 25-line mark in your
template. Happy to trim the logging or split it if you prefer something smaller.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

I could not reproduce against a live Enable Banking account, so the fix is verified via the unit
tests and by reasoning about the stack trace in the issue rather than end-to-end.
