### PR TITLE
Handle mixed auto-import exit codes

### DIFF
--- a/app/Console/AutoImportResult.php
+++ b/app/Console/AutoImportResult.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * AutoImportResult.php
+ * Copyright (c) 2026 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace App\Console;
+
+use App\Enums\ExitCode;
+
+final readonly class AutoImportResult
+{
+    /**
+     * @param array<string, int> $result
+     */
+    public function __construct(
+        private array $result
+    ) {}
+
+    /**
+     * @return array<string, int>
+     */
+    public function getFailures(): array
+    {
+        $benign = [ExitCode::SUCCESS->value, ExitCode::NOTHING_WAS_IMPORTED->value];
+
+        return array_filter($this->result, static fn(int $code): bool => !in_array($code, $benign, true));
+    }
+
+    public function getExitCode(): ExitCode
+    {
+        $failures = $this->getFailures();
+        if (0 === count($failures)) {
+            return in_array(ExitCode::SUCCESS->value, $this->result, true) ? ExitCode::SUCCESS : ExitCode::NOTHING_WAS_IMPORTED;
+        }
+
+        $distinct = array_unique($failures);
+
+        return 1 === count($distinct) ? ExitCode::from((int) reset($distinct)) : ExitCode::GENERAL_ERROR;
+    }
+}

--- a/app/Console/Commands/AutoImport.php
+++ b/app/Console/Commands/AutoImport.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Console\AutoImportResult;
 use App\Console\AutoImports;
 use App\Console\HaveAccess;
 use App\Console\VerifyJSON;
@@ -48,7 +49,7 @@ final class AutoImport extends Command
      */
     public function handle(): int
     {
-        $access    = $this->haveAccess(true);
+        $access = $this->haveAccess(true);
         if (false === $access) {
             $this->error(sprintf('[a] No access, or no connection is possible to your local Firefly III instance at %s.', config('importer.url')));
             Log::error(sprintf('[%s] Exit code is %s.', config('importer.version'), ExitCode::NO_CONNECTION->name));
@@ -56,8 +57,8 @@ final class AutoImport extends Command
             return ExitCode::NO_CONNECTION->value;
         }
 
-        $argument  = (string) $this->argument('directory');
-        $argument  = '' === $argument ? './' : $argument;
+        $argument = (string) $this->argument('directory');
+        $argument = '' === $argument ? './' : $argument;
 
         $directory = realpath($argument);
         if (false === $directory) {
@@ -75,7 +76,7 @@ final class AutoImport extends Command
         }
         $this->line(sprintf('[%s] Going to automatically import everything found in %s (%s)', config('importer.version'), $directory, $argument));
 
-        $files     = $this->getFiles($directory);
+        $files = $this->getFiles($directory);
         if (0 === count($files)) {
             $this->info(sprintf('There are no files in directory %s', $directory));
             $this->info('To learn more about this process, read the docs:');
@@ -87,22 +88,18 @@ final class AutoImport extends Command
         }
         $this->line(sprintf('Found %d (importable +) JSON file sets in %s.', count($files), $directory));
 
-        $result    = $this->importFiles($directory, $files);
-        $unique    = array_unique($result);
-        if (1 === count($unique)) {
-            return (int) reset($result);
-        }
-        if (count($unique) > 0) {
-            $this->warn('Multiple return codes found. Some imports may have failed');
-            foreach ($result as $file => $code) {
+        $result   = new AutoImportResult($this->importFiles($directory, $files));
+        $failures = $result->getFailures();
+        if (count($failures) > 0) {
+            $this->warn('Some imports failed');
+            foreach ($failures as $file => $code) {
                 $this->warn(sprintf('File %s returned code #%d', $file, $code));
             }
-            Log::error(sprintf('[%s] Exit code is %s.', config('importer.version'), ExitCode::GENERAL_ERROR->name));
-
-            return ExitCode::GENERAL_ERROR->value;
         }
-        Log::error(sprintf('[%s] Exit code is %s.', config('importer.version'), ExitCode::SUCCESS->name));
 
-        return ExitCode::SUCCESS->value;
+        $exitCode = $result->getExitCode();
+        Log::error(sprintf('[%s] Exit code is %s.', config('importer.version'), $exitCode->name));
+
+        return $exitCode->value;
     }
 }

--- a/tests/Unit/Console/AutoImportResultTest.php
+++ b/tests/Unit/Console/AutoImportResultTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * AutoImportResultTest.php
+ * Copyright (c) 2026 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console;
+
+use App\Console\AutoImportResult;
+use App\Enums\ExitCode;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \App\Console\AutoImportResult
+ */
+final class AutoImportResultTest extends TestCase
+{
+    public static function exitCodeProvider(): iterable
+    {
+        yield 'mixed successful and quiet imports' => [['one.json' => 73, 'two.json' => 0], ExitCode::SUCCESS];
+
+        yield 'only quiet imports' => [['one.json' => 73, 'two.json' => 73], ExitCode::NOTHING_WAS_IMPORTED];
+
+        yield 'one distinct failure' => [['one.json' => 74, 'two.json' => 74], ExitCode::AGREEMENT_EXPIRED];
+
+        yield 'one failure and one quiet import' => [['one.json' => 74, 'two.json' => 73], ExitCode::AGREEMENT_EXPIRED];
+
+        yield 'distinct failures' => [['one.json' => 74, 'two.json' => 75], ExitCode::GENERAL_ERROR];
+    }
+
+    /**
+     * @param array<string, int> $result
+     */
+    #[DataProvider('exitCodeProvider')]
+    public function testExitCode(array $result, ExitCode $expected): void
+    {
+        $this->assertSame($expected, new AutoImportResult($result)->getExitCode());
+    }
+
+    public function testFailuresExcludeSuccessfulAndQuietImports(): void
+    {
+        $result = new AutoImportResult([
+            'imported.json' => ExitCode::SUCCESS->value,
+            'quiet.json'    => ExitCode::NOTHING_WAS_IMPORTED->value,
+            'expired.json'  => ExitCode::AGREEMENT_EXPIRED->value
+        ]);
+
+        $this->assertSame(['expired.json' => ExitCode::AGREEMENT_EXPIRED->value], $result->getFailures());
+    }
+}


### PR DESCRIPTION
#### Reference issues and PRs

I didn't create an issue for this and didn't find one. Happy to create one if necessary. (First time contributor so not sure about what the expectations are).

#### What does this implement/fix? Explain your changes.

Background: When running multiple imports that have a mixed result of SUCCESS and NOTHING_WAS_IMPORTED, I want a clean exit code, not an error so my alerting doesnt trigger.

Treat SUCCESS and NOTHING_WAS_IMPORTED as benign outcomes. Return SUCCESS when any import succeeds and NOTHING_WAS_IMPORTED when all imports are quiet.

Preserve a single distinct failure code, use GENERAL_ERROR for multiple failure codes, and report only files that failed.

I decided to add a results class for easier testability.

Formatted AutoImport while I was there.

#### AI usage disclosure

I used AI assistance for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?

@JC5

