### PR TITLE
Have SimpleFIN work backwards for an Import Everything

### DIFF
--- a/app/Services/SimpleFIN/Request/AccountsRequest.php
+++ b/app/Services/SimpleFIN/Request/AccountsRequest.php
@@ -80,7 +80,9 @@ final class AccountsRequest extends SimpleFINRequest
             // add empty array to chunks.
             $chunks[] = [];
         }
-        $accountResponse = null;
+        $accountResponse  = null;
+        $emptyChunkStreak = 0;
+        $tripAfterChunks  = max(1, (int) ceil(config('simplefin.trip_after_empty_days') / $chunkSize));
         Log::debug(sprintf('Collected %d chunks(s)', count($chunks)));
         foreach ($chunks as $index => $chunk) {
             Log::debug(sprintf('Chunk #%d', $index + 1), $chunk);
@@ -126,15 +128,20 @@ final class AccountsRequest extends SimpleFINRequest
             if (null !== $response) {
                 $body = (string) $response->getBody();
             }
+
+            $newResponse           = new AccountsResponse($response);
+            $chunkTransactionCount = 0;
+            foreach ($newResponse->getAccounts() as $chunkAccount) {
+                $chunkTransactionCount += count($chunkAccount->transactions);
+            }
+            Log::debug(sprintf('Chunk #%d returned %d transaction(s).', $index + 1, $chunkTransactionCount));
+
             if (null !== $accountResponse) {
                 Log::debug('Append to new account response.');
-                // append to one.
-                $newResponse = new AccountsResponse($response);
                 $accountResponse->appendFromArray($newResponse->getAccounts());
-            }
-            if (null === $accountResponse) {
+            } else {
                 Log::debug('Create new account response.');
-                $accountResponse = new AccountsResponse($response);
+                $accountResponse = $newResponse;
             }
 
             // store fake data in new thing:
@@ -146,6 +153,17 @@ final class AccountsRequest extends SimpleFINRequest
                 } catch (FilesystemException $e) {
                     Log::error(sprintf('Could not store fake data: %s', $e->getMessage()));
                 }
+            }
+
+            $emptyChunkStreak = 0 === $chunkTransactionCount ? $emptyChunkStreak + 1 : 0;
+            if (count($chunks) > 1 && $emptyChunkStreak >= $tripAfterChunks) {
+                Log::debug(sprintf(
+                    '%d consecutive empty chunk(s) (~%d days) with no transactions -- assuming no history further back, stopping early instead of requesting the remaining %d chunk(s).',
+                    $emptyChunkStreak,
+                    $emptyChunkStreak * $chunkSize,
+                    count($chunks) - $index - 1
+                ));
+                break;
             }
         }
 
@@ -183,23 +201,26 @@ final class AccountsRequest extends SimpleFINRequest
     private function chunkByTime(int $start, int $end): array
     {
         Log::debug(sprintf('Now at %s', __METHOD__));
-        $return       = [];
-        $chunkSize    = config('simplefin.max_chunk_size');
-        $size         = $chunkSize * 24 * 60 * 60;
-        $currentStart = $start;
+        $return     = [];
+        $chunkSize  = config('simplefin.max_chunk_size');
+        $size       = $chunkSize * 24 * 60 * 60;
+        $currentEnd = $end;
         Log::debug(sprintf('Start is %d (%s)', $start, Carbon::createFromTimestamp($start, config('app.timezone'))->toW3cString()));
         Log::debug(sprintf('End is   %d (%s)', $end, Carbon::createFromTimestamp($end, config('app.timezone'))->toW3cString()));
-        while ($currentStart <= $end) {
-            $currentEnd = $currentStart + $size;
-            if ($currentEnd > $end) {
-                $currentEnd = $end;
+        // Newest chunk first, so a consumer that stops on consecutive empty
+        // chunks bails out once it's walked past real history, instead of
+        // needing every chunk back to $start queued up before it can tell.
+        while ($currentEnd > $start) {
+            $currentStart = $currentEnd - $size;
+            if ($currentStart < $start) {
+                $currentStart = $start;
             }
             $return[]   = ['start-date' => $currentStart, 'end-date' => $currentEnd];
             Log::debug(sprintf('Add chunk on index #%d', count($return) - 1));
             Log::debug(sprintf('Start of chunk is %d (%s)', $currentStart, Carbon::createFromTimestamp($currentStart, config('app.timezone'))->toW3cString()));
             Log::debug(sprintf('End of chunk is   %d (%s)', $currentEnd, Carbon::createFromTimestamp($currentEnd, config('app.timezone'))->toW3cString()));
 
-            $currentStart += $size;
+            $currentEnd -= $size;
         }
 
         return $return;

--- a/app/Services/SimpleFIN/Request/AccountsRequest.php
+++ b/app/Services/SimpleFIN/Request/AccountsRequest.php
@@ -158,10 +158,8 @@ final class AccountsRequest extends SimpleFINRequest
             $emptyChunkStreak = 0 === $chunkTransactionCount ? $emptyChunkStreak + 1 : 0;
             if (count($chunks) > 1 && $emptyChunkStreak >= $tripAfterChunks) {
                 Log::debug(sprintf(
-                    '%d consecutive empty chunk(s) (~%d days) with no transactions -- assuming no history further back, stopping early instead of requesting the remaining %d chunk(s).',
-                    $emptyChunkStreak,
-                    $emptyChunkStreak * $chunkSize,
-                    count($chunks) - $index - 1
+                    'Stopping early because more than %d days with no transactions to save SimpleFIN API requests.',
+                    $emptyChunkStreak * $chunkSize
                 ));
                 break;
             }

--- a/config/simplefin.php
+++ b/config/simplefin.php
@@ -35,6 +35,7 @@ return [
     'origin_url'                      => env('SIMPLEFIN_CORS_ORIGIN_URL', ''),
 
     'max_chunk_size'                  => 89, // in days
+    'trip_after_empty_days'           => env('SIMPLEFIN_TRIP_AFTER_EMPTY_DAYS', 180),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The SimpleFIN "all transaction" importer seemed to walk forward from some long time in the past even on the fixed "develop" branch, which for me still caused a high number of SimpleFIN calls even though develop partially fixed the issue.  This strategy walks back and stops when all accounts show no transactions over a long (adjustable) period. 

For me, this reduced about 21 calls to just 6, which felt better for SimpleFIN that expects a handful.

Solely for your consideration.


🙌 Thanks for contributing a pull request. Before you continue:

1. If you introduce new third party data providers, talk to me FIRST.
2. If your PR is more than 25 lines, talk to me FIRST.
3. If you fix spelling or code comments, talk to me FIRST.

This is to prevent AI bots, low-effort PRs and spam. Sorry about that.

Wanna talk to me? Open a GitHub Issue, Discussion, or email me: james@firefly-iii.org

👀 Please ensure you have taken a look at the contribution guidelines:
https://docs.firefly-iii.org/explanation/support/#contributing-code

Remember that your PR may be CLOSED:

1. If you do not refer to an existing issue, your PR will be CLOSED.
2. If you open a PR on the main branch, your PR will be CLOSED.
3. If you only fix a spelling error or code comment, your PR will be CLOSED.

Again, this is to prevent AI bots, low-effort PRs and spam. I apologize for the harsh tone.

But if you made it this far thanks again for contributing, and happy developing!

-->

#### Reference issues and PRs

#12538

#### What does this implement/fix? Explain your changes.

Many SimpleFIN calls.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://docs.firefly-iii.org/explanation/support/#automated-contributions-policy

If you remove or skip this disclosure, your PR may be ignored.
-->
I used AI assistance for:
- [X] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation (sort of I tested myself and asked AI to confirm what I was seeing)
- [ ] Documentation (including examples)
- [X] Research and understanding


#### Any other comments?

<!--
Thanks for contributing!
-->

@JC5

