### PR TITLE
Add a data provider for Akahu

### DIFF
--- a/app/Api/Controllers/ImportFlow/ValidationController.php
+++ b/app/Api/Controllers/ImportFlow/ValidationController.php
@@ -31,6 +31,7 @@ use App\Services\LunchFlow\AuthenticationValidator as LunchFlowValidator;
 use App\Services\Nordigen\AuthenticationValidator as NordigenValidator;
 use App\Services\SimpleFIN\AuthenticationValidator as SimpleFINValidator;
 use App\Services\Sophtron\AuthenticationValidator as SophtronValidator;
+use App\Services\Akahu\AuthenticationValidator as AkahuValidator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
 
@@ -44,6 +45,7 @@ final class ValidationController extends Controller
             'lunchflow'              => $this->validateLunchFlow(),
             'sophtron'               => $this->validateSophtron(),
             'eb'                     => $this->validateEnableBanking(),
+            'akahu'                  => $this->validateAkahu(),
             'file'                   => response()->json(['result' => 'OK']),
             default                  => response()->json(['result' => 'NOK', 'message' => 'Unknown provider'])
         };
@@ -146,6 +148,28 @@ final class ValidationController extends Controller
             return response()->json(['result' => 'NODATA']);
         }
         Log::info(sprintf('[%s] All OK in validateEnableBanking.', config('importer.version')));
+
+        return response()->json(['result' => 'OK']);
+    }
+
+    private function validateAkahu(): JsonResponse
+    {
+        Log::debug(sprintf('[%s] Now in %s', config('importer.version'), __METHOD__));
+        $validator = new AkahuValidator();
+        $result    = $validator->validate();
+
+        if (AuthenticationStatus::ERROR === $result) {
+            Log::error('Error: Could not validate Akahu credentials.');
+
+            return response()->json(['result' => 'NOK']);
+        }
+        if (AuthenticationStatus::NODATA === $result) {
+            Log::error('No data: Could not validate Akahu credentials.');
+
+            return response()->json(['result' => 'NODATA']);
+        }
+
+        Log::info(sprintf('[%s] All OK in %s.', config('importer.version'), __METHOD__));
 
         return response()->json(['result' => 'OK']);
     }

--- a/app/Http/Controllers/Import/AuthenticateController.php
+++ b/app/Http/Controllers/Import/AuthenticateController.php
@@ -32,6 +32,7 @@ use App\Services\LunchFlow\AuthenticationValidator as LunchFlowValidator;
 use App\Services\Nordigen\AuthenticationValidator as NordigenValidator;
 use App\Services\Shared\Authentication\AuthenticationValidatorInterface;
 use App\Services\Sophtron\AuthenticationValidator as SophtronValidator;
+use App\Services\Akahu\AuthenticationValidator as AkahuValidator;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -114,6 +115,9 @@ final class AuthenticateController extends Controller
 
             case 'eb':
                 return new EnableBankingValidator();
+
+            case 'akahu':
+                return new AkahuValidator();
         }
 
         return null;

--- a/app/Http/Controllers/Import/ConfigurationController.php
+++ b/app/Http/Controllers/Import/ConfigurationController.php
@@ -117,6 +117,15 @@ final class ConfigurationController extends Controller
 
                     return redirect()->route('eb-select-bank.index', [$identifier])->withErrors($messages);
                 }
+                if ($messages->has('no_accounts') && 'akahu' === $flow) {
+                    $importJob->setServiceAccounts([]);
+                    $importJob->setState('needs_connection_details');
+                    $this->repository->saveToDisk($importJob);
+
+                    $flow = 'akahu';
+                    session()->put('error', $messages->get('no_accounts')[0]);
+                    return redirect()->route('authenticate-flow.index', compact('flow'));
+                }
 
                 // if the agreement has expired, show error and exit gracefully.
 
@@ -170,6 +179,7 @@ final class ConfigurationController extends Controller
             'lunchflow' => ImportServiceAccount::convertLunchFlowArray($serviceAccounts),
             'sophtron'  => ImportServiceAccount::convertSophtronArray($serviceAccounts),
             'eb'        => ImportServiceAccount::convertEnableBankingArray($serviceAccounts),
+            'akahu'     => ImportServiceAccount::convertAkahuArray($serviceAccounts),
             'file'      => [],
             default     => throw new ImporterErrorException(sprintf('Cannot mergeAccountLists("%s")', $flow))
         };

--- a/app/Http/Controllers/Import/MapController.php
+++ b/app/Http/Controllers/Import/MapController.php
@@ -261,6 +261,7 @@ final class MapController extends Controller
             || 'sophtron' === $importJob->getFlow()
             || 'lunchflow' === $importJob->getFlow()
             || 'eb' === $importJob->getFlow()
+            || 'akahu' === $importJob->getFlow()
         ) {
             // FIXME should be in a helper or something generic.
             // index 0, opposing account name:

--- a/app/Http/Controllers/Import/UploadController.php
+++ b/app/Http/Controllers/Import/UploadController.php
@@ -208,6 +208,11 @@ final class UploadController extends Controller
                 Log::debug('No extra steps for Enable Banking.');
 
                 break;
+
+            case 'akahu':
+                Log::debug('No extra steps for Akahu.');
+
+                break;
         }
 
         // stop again if any errors:

--- a/app/Repository/ImportJob/ImportJobRepository.php
+++ b/app/Repository/ImportJob/ImportJobRepository.php
@@ -30,6 +30,7 @@ use App\Services\CSV\Mapper\TransactionCurrencies;
 use App\Services\EnableBanking\Validation\NewJobDataCollector as EnableBankingNewJobDataCollector;
 use App\Services\LunchFlow\Validation\NewJobDataCollector as LunchFlowNewJobDataCollector;
 use App\Services\Nordigen\Validation\NewJobDataCollector as NordigenNewJobDataCollector;
+use App\Services\Akahu\Validation\NewJobDataCollector as AkahuNewJobDataCollector;
 use App\Services\Session\Constants;
 use App\Services\Shared\Authentication\SecretManager;
 use App\Services\Shared\Configuration\Configuration;
@@ -213,6 +214,15 @@ final class ImportJobRepository
 
             case 'eb':
                 $validator     = new EnableBankingNewJobDataCollector();
+                $validator->setImportJob($importJob);
+                $messageBag    = $validator->collectAccounts();
+                $importJob     = $validator->getImportJob();
+                $configuration = $importJob->getConfiguration();
+
+                break;
+
+            case 'akahu':
+                $validator     = new AkahuNewJobDataCollector();
                 $validator->setImportJob($importJob);
                 $messageBag    = $validator->collectAccounts();
                 $importJob     = $validator->getImportJob();

--- a/app/Services/Akahu/Authentication/SecretManager.php
+++ b/app/Services/Akahu/Authentication/SecretManager.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Authentication;
+
+final class SecretManager
+{
+    public const string APP_ID_TOKEN = 'app_id_token';
+    public const string USER_ACCESS_TOKEN = 'user_access_token';
+
+    public static function getAppIdToken(): string
+    {
+        if (session()->exists(self::APP_ID_TOKEN)) {
+            return session()->get(self::APP_ID_TOKEN);
+        }
+
+        return config(sprintf('akahu.%s', self::APP_ID_TOKEN));
+    }
+
+    public static function getUserAccessToken(): string
+    {
+        if (session()->exists(self::USER_ACCESS_TOKEN)) {
+            return session()->get(self::USER_ACCESS_TOKEN);
+        }
+
+        return config(sprintf('akahu.%s', self::USER_ACCESS_TOKEN));
+    }
+
+    public static function setAppIdToken(string $token): void
+    {
+        session()->put(self::APP_ID_TOKEN, $token);
+    }
+
+    public static function setUserAccessToken(string $token): void
+    {
+        session()->put(self::USER_ACCESS_TOKEN, $token);
+    }
+
+    public static function hasAppIdToken(): bool
+    {
+        return '' !== self::getAppIdToken();
+    }
+
+    public static function hasUserAccessToken(): bool
+    {
+        return '' !== self::getUserAccessToken();
+    }
+
+    public static function getSecrets(): array
+    {
+        return [
+            self::APP_ID_TOKEN => SecretManager::getAppIdToken(),
+            self::USER_ACCESS_TOKEN => SecretManager::getUserAccessToken(),
+        ];
+    }
+
+    public static function setSecrets(array $data): void
+    {
+        SecretManager::setAppIdToken($data[self::APP_ID_TOKEN]);
+        SecretManager::setUserAccessToken($data[self::USER_ACCESS_TOKEN]);
+    }
+}

--- a/app/Services/Akahu/AuthenticationValidator.php
+++ b/app/Services/Akahu/AuthenticationValidator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu;
+
+use App\Services\Shared\Authentication\AuthenticationValidatorInterface;
+use App\Services\Enums\AuthenticationStatus;
+use Illuminate\Support\Facades\Log;
+use App\Services\Akahu\Authentication\SecretManager;
+
+final class AuthenticationValidator implements AuthenticationValidatorInterface
+{
+    public function validate(): AuthenticationStatus
+    {
+        Log::debug(sprintf('Now at %s', __METHOD__));
+
+        if (!SecretManager::hasAppIdToken() || !SecretManager::hasUserAccessToken()) {
+            return AuthenticationStatus::NODATA;
+        }
+
+        // If were in a reauthentication flow then return NODATA to let the
+        // user reauthenticate.
+        if (session()->has('akahu_reauthenticate')) {
+            if ('true' === session()->get('akahu_reauthenticate')) {
+                return AuthenticationStatus::NODATA;
+            }
+        }
+
+        return AuthenticationStatus::AUTHENTICATED;
+    }
+
+    public function getData(): array
+    {
+        return SecretManager::getSecrets();
+    }
+
+    public function setData(array $data): void
+    {
+        // Clear the reauthentication flow flag whenever we set new data
+        session()->forget('akahu_reauthenticate');
+
+        SecretManager::setSecrets($data);
+    }
+}

--- a/app/Services/Akahu/Conversion/AkahuNoteBuilder.php
+++ b/app/Services/Akahu/Conversion/AkahuNoteBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Conversion;
+
+use App\Services\Akahu\Model\Transaction\Transaction;
+use App\Services\Shared\Conversion\NoteBuilder;
+use App\Services\Shared\Conversion\Field;
+
+final class AkahuNoteBuilder extends NoteBuilder
+{
+    private ?Transaction $transaction = null;
+
+    public function __construct(Transaction $transaction)
+    {
+        $this->transaction = $transaction;
+    }
+
+    /**
+     * Builds notes on this transaction to give to Firefly III
+     */
+    public function build(): string
+    {
+        $meta = $this->transaction->getMeta();
+
+        $this->renderSection('Transaction Metadata', [
+            new Field('Particulars', $meta?->getParticulars()),
+            new Field('Code', $meta?->getCode()),
+            new Field('Reference', $meta?->getReference()),
+            new Field('Other account', $meta?->getOtherAccount())
+        ]);
+
+        $this->renderSection('Eftpos Infomation', [
+            new Field('Card Suffix', $meta?->getCardSuffix()),
+            new Field('Logo', $meta?->getLogo()),
+        ]);
+
+        $merchant = $this->transaction->getMerchant();
+
+        $this->renderSection('Merchant Infomation', [
+            new Field('Name', $merchant?->getName()),
+            new Field('Website', $merchant?->getWebsite()),
+            new Field('NZBN (https://www.nzbn.govt.nz/)', $merchant?->getNZBN()),
+        ]);
+
+        $category = $this->transaction->getCategory();
+
+        $this->renderSection('Akahu NZFCC classification (https://nzfcc.org/)', [
+            new Field('Name', $category?->getName()),
+            new Field('Personal finance category', $category
+                ?->getPersonalFinanceGroup()
+                ?->getName()),
+        ]);
+
+        return $this->getNotes();
+    }
+}

--- a/app/Services/Akahu/Conversion/RoutineManager.php
+++ b/app/Services/Akahu/Conversion/RoutineManager.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Conversion;
+
+use App\Models\ImportJob;
+use App\Services\Shared\Conversion\RoutineManagerInterface;
+use App\Services\Akahu\Request\GetTransactionsRequest;
+use App\Services\Akahu\Request\AkahuDateRange;
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Shared\Conversion\CreatesAccounts;
+use App\Repository\ImportJob\ImportJobRepository;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+
+final class RoutineManager implements RoutineManagerInterface
+{
+    use CreatesAccounts;
+
+    private ImportJob $importJob;
+
+    private const int CREATE_ACCOUNT_SENTINEL_ID = 0;
+
+    public function __construct(ImportJob $importJob)
+    {
+        $this->importJob = $importJob;
+        $this->repository = new ImportJobRepository();
+        $this->setExistingServiceAccounts($importJob->getServiceAccounts());
+    }
+
+    public function getServiceAccounts(): array
+    {
+        return $this->importJob->getServiceAccounts();
+    }
+
+    public function getImportJob(): ImportJob
+    {
+        return $this->importJob;
+    }
+
+    public function start(): array
+    {
+        $configuration = $this->importJob->getConfiguration();
+        $accounts = $configuration->getAccounts();
+        $transactions = [];
+
+        foreach($accounts as $akahuAccountId => $maybeFireflyAccountId) {
+            $fireflyAccountId = $this->ensureFireflyAccountId($maybeFireflyAccountId, $akahuAccountId);
+            $dateRange = new AkahuDateRange($configuration);
+
+            $fetcher = new TransactionFetcher(
+                $akahuAccountId,
+                $fireflyAccountId,
+                $dateRange,
+                $this->importJob
+            );
+            $converter = new TransactionConverter($fetcher);
+            $accountTransactions = $converter->convert();
+
+            array_push($transactions, ...$accountTransactions);
+        }
+
+        return $transactions;
+    }
+
+    private function ensureFireflyAccountId(int $fireflyAccountId, string $akahuAccountId): int
+    {
+        if (self::CREATE_ACCOUNT_SENTINEL_ID === $fireflyAccountId) {
+            Log::debug(sprintf('Creating new account for account "%s".', $akahuAccountId));
+            return $this->createNewAccount($akahuAccountId);
+        }
+
+        return $fireflyAccountId;
+    }
+}

--- a/app/Services/Akahu/Conversion/TransactionConverter.php
+++ b/app/Services/Akahu/Conversion/TransactionConverter.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Conversion;
+
+use App\Models\ImportJob;
+use App\Services\Akahu\Model\Transaction\Transaction;
+use App\Services\Shared\Configuration\Configuration; use App\Support\Http\CollectsAccounts;
+use App\Support\Internal\DuplicateSafetyCatch;
+use Carbon\Carbon;
+use GrumpyDictator\FFIIIApiSupport\Exceptions\ApiHttpException;
+use Illuminate\Support\Facades\Log;
+use App\Services\Shared\Authentication\SecretManager;
+use GrumpyDictator\FFIIIApiSupport\Request\GetAccountRequest;
+use BcMath\Number;
+use App\Support\Facades\Steam;
+
+final class TransactionConverter
+{
+    use CollectsAccounts;
+    use DuplicateSafetyCatch;
+
+    private TransactionFetcher $transactionFetcher;
+    private array $targetAccounts;
+    private int $accountDecimalPlaces;
+
+    public function __construct(TransactionFetcher $transactionFetcher)
+    {
+        $this->transactionFetcher = $transactionFetcher;
+
+        $fireflyAccountId = $transactionFetcher->getFireflyAccountId();
+        // $this->accountDecimalPlaces = $this->getAccountDecimalPlaces($fireflyAccountId);
+    }
+
+    public function convert(): array
+    {
+        $this->targetAccounts = $this->collectAllTargetAccounts();
+        $fireflyAccountId = $this->transactionFetcher->getFireflyAccountId();
+        $akahuTransactions = $this->transactionFetcher->fetch();
+
+        $result = [];
+        $total = count($akahuTransactions);
+
+        foreach ($akahuTransactions as $index => $akahuTransaction) {
+            Log::debug(sprintf('[%d/%d] Converting transaction', $index + 1, $total));
+            $result[] = $this->convertTransaction($akahuTransaction);
+            Log::debug(sprintf('[%d/%d] Done converting transaction.', $index + 1, $total));
+        }
+
+        return $result;
+    }
+
+    public function getAccountDecimalPlaces(int $fireflyAccountId): ?int
+    {
+        $token = SecretManager::getAccessToken();
+        $baseUrl = SecretManager::getBaseUrl();
+
+        $request = new GetAccountRequest($baseUrl, $token);
+        $request->setVerify(config('importer.connection.verify'));
+        $request->setTimeOut(config('importer.connection.timeout'));
+        $request->setId($fireflyAccountId);
+
+        try {
+            $result = $request->get();
+        } catch (ApiHttpException $e) {
+            Log::error('Could not get Firefly III account.');
+            Log::debug($e->getMessage());
+
+            return null;
+        }
+
+        return $result->getAccount()->currencyDecimalPlaces;
+    }
+
+    private function convertTransaction(Transaction $akahuTransaction): array
+    {
+        $configuration = $this->transactionFetcher->getImportJob()->getConfiguration();
+        $noteBuilder = new AkahuNoteBuilder($akahuTransaction);
+
+        $fireflyRequest = [
+            'apply_rules'             => $configuration->isRules(),
+            'fire_webhooks'           => $configuration->isWebhooks(),
+            'error_if_duplicate_hash' => $configuration->isIgnoreDuplicateTransactions(),
+            'transactions'            => [],
+        ];
+
+        $fireflyTransaction = [
+            'date'                   => $akahuTransaction->getDate()->toRfc3339String(),
+            'amount'                 => (string) $akahuTransaction->getAmount(),
+            'description'            => $akahuTransaction->getDescription(),
+            'order'                  => 0,
+            'notes'                  => $noteBuilder->build(),
+        ];
+
+        $conversion = $akahuTransaction->getMeta()?->getConversion();
+        if (!is_null($conversion)) {
+            $amount = $conversion?->getAmount();
+            $currency = $conversion?->getCurrency();
+
+            if (!is_null($amount) && !is_null($currency)) {
+                $fireflyTransaction['foreign_amount'] = Steam::bcstringify($amount, 2);
+                $fireflyTransaction['foreign_currency_code'] = $currency;
+            }
+        }
+
+        $akahuId = $akahuTransaction->getAkahuId();
+        if (!is_null($akahuId)) {
+            $fireflyTransaction['external_id'] = $akahuId;
+        }
+
+        $zero = new Number('0');
+        if ($akahuTransaction->getAmount()->compare($zero) >= 0) {
+            Log::debug('Amount is positive or zero: assume transfer or deposit');
+            $fireflyTransaction = $this->appendDepositInfo($fireflyTransaction, $akahuTransaction);
+        }
+        if ($akahuTransaction->getAmount()->compare($zero) < 0) {
+            Log::debug('Amount is negative: assume transfer or withdrawal');
+            $fireflyTransaction = $this->appendWithdrawalInfo($fireflyTransaction, $akahuTransaction);
+        }
+
+        $fireflyRequest['transactions'][] = $fireflyTransaction;
+        return $fireflyRequest;
+    }
+
+    private function appendDepositInfo(array $fireflyTransaction, Transaction $akahuTransaction): array
+    {
+        $fireflyTransaction['type'] = 'deposit';
+        // FIXME: pull dp from api
+        $fireflyTransaction['amount'] = Steam::bcstringify($akahuTransaction->getAmount(), 2);
+        $fireflyTransaction['destination_id'] = $this->transactionFetcher->getFireflyAccountId();
+        $fireflyTransaction['source_name'] = '(unknown source)';
+
+        $sourceBban = $akahuTransaction->getMeta()?->getOtherAccount();
+
+        if (!is_null($sourceBban)) {
+            $fireflyTransaction['source_name'] = $sourceBban;
+        }
+
+        return $fireflyTransaction;
+    }
+
+    private function appendWithdrawalInfo(array $fireflyTransaction, Transaction $akahuTransaction): array
+    {
+        $fireflyTransaction['type'] = 'withdrawal';
+        $amount = $akahuTransaction->getAmount() * new Number('-1');
+        // FIXME: pull dp from api
+        $fireflyTransaction['amount'] = Steam::bcstringify($amount, 2);
+        $fireflyTransaction['source_id'] = $this->transactionFetcher->getFireflyAccountId();
+        $fireflyTransaction['destination_name'] = '(unknown source)';
+
+        $destinationBban = $akahuTransaction->getMeta()?->getOtherAccount();
+        $destinationMerchantName = $akahuTransaction->getMerchant()?->getName();
+
+        if (!is_null($destinationMerchantName)) {
+            $fireflyTransaction['destination_name'] = $destinationMerchantName;
+        }
+
+        if (!is_null($destinationBban)) {
+            $fireflyTransaction['destination_name'] = $destinationBban;
+        }
+
+        return $fireflyTransaction;
+    }
+}

--- a/app/Services/Akahu/Conversion/TransactionFetcher.php
+++ b/app/Services/Akahu/Conversion/TransactionFetcher.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Conversion;
+
+use App\Models\ImportJob;
+use App\Services\Shared\Conversion\RoutineManagerInterface;
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Akahu\Request\GetTransactionsRequest;
+use App\Exceptions\ImporterHttpException;
+use Illuminate\Support\Facades\Log;
+use App\Services\Akahu\Request\AkahuDateRange;
+use Carbon\Carbon;
+
+final class TransactionFetcher
+{
+    private string $akahuAccountId;
+    private int $fireflyAccountId;
+    private ?Carbon $startDate;
+    private ?Carbon $endDate;
+    private ImportJob $importJob;
+    private AkahuDateRange $dateRange;
+
+    public function __construct(
+        string $akahuAccountId,
+        int $fireflyAccountId,
+        AkahuDateRange $dateRange,
+        ImportJob $importJob,
+    )
+    {
+        $this->akahuAccountId = $akahuAccountId;
+        $this->fireflyAccountId = $fireflyAccountId;
+        $this->dateRange = $dateRange;
+        $this->importJob = $importJob;
+    }
+
+    public function fetch(): array
+    {
+        $request = new GetTransactionsRequest(
+            $this->akahuAccountId,
+            $this->dateRange,
+        );
+
+        try {
+            $response = $request->get();
+        } catch (ImporterHttpException $e) {
+            $msg = sprintf(
+                "Failed get transactions from the Akahu api: %s",
+                $e->getMessage()
+            );
+
+            Log::error($msg);
+            $this->importJob->conversionStatus->addError(0, e($msg));
+
+            return [];
+        }
+
+        $transactions = $response->getTransactions();
+        $akahuAccountId = $this->akahuAccountId;
+        $account = array_find(
+            $this->importJob->getServiceAccounts(),
+            function(Account $account) use ($akahuAccountId) {
+                return $akahuAccountId === $account->getAkahuId();
+            }
+        );
+
+        $msg = sprintf(
+            'Successfully fetched %d transactions for Akahu account "%s"',
+            count($transactions),
+            $account->getName()
+        );
+
+        $this->importJob->conversionStatus->addMessage(0, e($msg));
+
+        return $transactions;
+    }
+
+    public function getAkahuAccountId(): string
+    {
+        return $this->akahuAccountId;
+    }
+
+    public function getFireflyAccountId(): int
+    {
+        return $this->fireflyAccountId;
+    }
+
+    public function getImportJob(): ImportJob
+    {
+        return $this->importJob;
+    }
+}

--- a/app/Services/Akahu/Model/Account/Account.php
+++ b/app/Services/Akahu/Model/Account/Account.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Account;
+
+use Carbon\Carbon;
+
+final class Account
+{
+    public const string ATTRIBUTE_TRANSACTIONS = 'TRANSACTIONS';
+    public const string ATTRIBUTE_PAYMENT_TO = 'PAYMENT_TO';
+    public const string ATTRIBUTE_PAYMENT_FROM = 'PAYMENT_FROM';
+
+    // The _id key is a unique identifier for the account in the Akahu system. It
+    // is always be prefixed by acc_ so that you can tell that it belongs to an account.
+    private ?string $akahuId = null;
+
+    // This tells you who the original account provider is (e.g. Demo Bank).
+    private ?Connection $connection = null;
+
+    // This is the name of the account.
+    private ?string $name = null;
+
+    // This attribute indicates the status of Akahu's connection to this account.
+    // It is possible for Akahu to lose the ability to authenticate with a financial
+    // institution if the user revokes Akahu's access directly via their institution, or
+    // changes their login credentials, which in some cases can cause our long-lived
+    // access to be revoked.
+    private ?string $akahuStatus = null;
+
+    // If the account has a well defined account number (eg. a bank account number, or
+    // credit card number) this will be defined here with a standard format across
+    // connections. This field will be the value `undefined` for accounts with KiwiSaver
+    // providers and investment platform accounts.
+    //
+    // For NZ banks, we use the common format `00-0000-0000000-00`.
+    // For credit cards, we return a redacted card number `1234-****-****-1234`
+    // or `****-****-****-1234`
+    private ?string $formattedAccount = null;
+
+    // This is a less defined part of our API that lets us expose data that may be
+    // specific to certain account types or financial institutions. An investment
+    // provider, for example, may expose a breakdown of investment results.
+    private ?array $meta = null;
+
+    // https://developers.akahu.nz/docs/the-account-model#payment_consents
+    // `payment_consents` is omitted as Firefly III makes no payments on the users behalf
+
+    // Akahu can refresh different parts of an account's data at different rates. The
+    // timestamps in the refreshed object tell you when that account data was last
+    // updated. When looking at a timestamp in here, you can think "Akahu's view of the
+    // account (balance/metadata/transactions) is up to date as of $TIME".
+    private ?Refreshed $refreshed = null;
+
+    // The account balance.
+    private ?Balance $balance = null;
+
+    // What sort of account this is. Akahu provides specific bank account types, and falls
+    // back to more general types for other types of connection.
+    private ?string $type = null;
+
+    // The list of attributes indicates what abilities an account has.
+    private ?array $attributes = null;
+
+    // https://developers.akahu.nz/docs/the-account-model#status
+    private const array AKAHU_STATUS_MAP = [
+        // Akahu can authenticate with the institution to retrieve data and/or
+        // initiate payments for this account.
+        'ACTIVE' => 'enabled',
+
+        // Akahu no longer has access to this account. Your application will
+        // still be able to access Akahu's cached copy of data for this account,
+        // but this will no longer be updated by refreshes. Write actions such
+        // as payments will no longer be available. Once an account is assigned
+        // the INACTIVE status, it will stay this way until the user re-establishes
+        // the connection. When your application observes an account with a
+        // status of INACTIVE, the user should be directed back to the Akahu
+        // OAuth flow or to https://my.akahu.nz/connections where they will be
+        // prompted to re-establish the connection.
+        'INACTIVE' => 'disabled',
+    ];
+
+    /**
+     * Parse an account structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $account = new self();
+
+        $account->akahuId = $json['_id'] ?? null;
+
+        $account->connection = isset($json['connection'])
+            ? Connection::fromJson($json['connection']) : null;
+
+        $account->name = $json['name'] ?? null;
+        $account->akahuStatus = $json['status'] ?? null;
+        $account->formattedAccount = $json['formatted_account'] ?? null;
+
+        $account->meta = $json['meta'] ?? null;
+
+        $account->refreshed = isset($json['refreshed'])
+            ? Refreshed::fromJson($json['refreshed']) : null;
+
+        $account->balance = isset($json['balance'])
+            ? Balance::fromJson($json['balance']) : null;
+
+        $account->type = $json['type'] ?? null;
+        $account->attributes = $json['attributes'] ?? null;
+
+        return $account;
+    }
+
+    /**
+     * Serialize an account structure to store on disk
+     */
+    public function toArray(): array
+    {
+        return array(
+            'class'            => self::class,
+            'akahuId'          => $this->akahuId,
+            'connection'       => $this->connection?->toArray(),
+            'name'             => $this->name,
+            'akahuStatus'      => $this->akahuStatus,
+            'formattedAccount' => $this->formattedAccount,
+            'meta'             => $this->meta,
+            'refreshed'        => $this->refreshed?->toArray(),
+            'balance'          => $this->balance?->toArray(),
+            'type'             => $this->type,
+            'attributes'       => $this->attributes,
+        );
+    }
+
+    /**
+     * Deserialize an account structure from disk
+     */
+    public static function fromArray(array $data): self
+    {
+        $account = new self();
+
+        $account->akahuId = $data['akahuId'] ?? null;
+
+        $account->connection = isset($data['connection'])
+            ? Connection::fromArray($data['connection']) : null;
+
+        $account->name = $data['name'] ?? null;
+        $account->akahuStatus = $data['akahuStatus'] ?? null;
+        $account->formattedAccount = $data['formattedAccount'] ?? null;
+        $account->meta = $data['meta'] ?? null;
+
+        $account->refreshed = isset($data['refreshed'])
+            ? Refreshed::fromArray($data['refreshed']) : null;
+
+        $account->balance = isset($data['balance'])
+            ? Balance::fromArray($data['balance']) : null;
+
+        $account->type = $data['type'] ?? null;
+
+        $account->attributes = $data['attributes'] ?? null;
+
+        return $account;
+    }
+
+    public function getAkahuId(): ?string
+    {
+        return $this->akahuId;
+    }
+
+    public function getConnection(): ?Connection
+    {
+        return $this->connection;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getAkahuStatus(): ?string
+    {
+        return $this->akahuStatus;
+    }
+
+    public function getFormattedAccount(): ?string
+    {
+        return $this->formattedAccount;
+    }
+
+    public function getMeta(): ?array
+    {
+        return $this->meta;
+    }
+
+    public function getRefreshed(): ?Refreshed
+    {
+        return $this->refreshed;
+    }
+
+    public function getBalance(): ?Balance
+    {
+        return $this->balance;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function getAttributes(): ?array
+    {
+        return $this->attributes;
+    }
+
+    //
+    // Helpers
+    //
+
+    public function getFireflyStatus(): string
+    {
+        return self::AKAHU_STATUS_MAP[$this->getAkahuStatus()];
+    }
+
+}

--- a/app/Services/Akahu/Model/Account/Balance.php
+++ b/app/Services/Akahu/Model/Account/Balance.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Account;
+
+use Carbon\Carbon;
+use BcMath\Number;
+use App\Support\Facades\Steam;
+use Illuminate\Support\Facades\Log;
+
+final class Balance
+{
+    // The current account balance. A negative balance indicates the amount owed
+    // to the account issuer. For example a checking account in overdraft will have
+    // a negative balance, same as the amount owed on a credit card or the
+    // principal remaining on a loan.
+    private ?Number $current = null;
+
+    // The balance that is currently available to the account holder.
+    private ?Number $available = null;
+
+    // The credit limit for this account. For example a credit card limit or an
+    // overdraft limit. This value is only present when provided directly by the
+    // connected financial institution.
+    private ?Number $limit = null;
+
+    // A boolean indicating whether this account is in overdraft.
+    private ?bool $overdrawn = null;
+
+    // The 3 letter ISO 4217 currency code that this balance is in (e.g. NZD).
+    private ?string $currency = null;
+
+    /**
+     * Parse a balance structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $balance = new self();
+
+        $balance->current = isset($json['current'])
+            ? Steam::bcnumber($json['current']) : null;
+        $balance->available = isset($json['available'])
+            ? Steam::bcnumber($json['available']) : null;
+        $balance->limit = isset($json['limit'])
+            ? Steam::bcnumber($json['limit']) : null;
+
+        $balance->overdrawn = $json['overdrawn'] ?? null;
+        $balance->currency = $json['currency'] ?? null;
+
+        return $balance;
+    }
+
+    /**
+     * Serialize a balance structure to store on disk
+     */
+    public function toArray(): array
+    {
+        return array(
+            'current' => serialize($this->current),
+            'available' => serialize($this->available),
+            'limit' => serialize($this->limit),
+            'overdrawn' => $this->overdrawn,
+            'currency' => $this->currency,
+        );
+    }
+
+    /**
+     * Deserialize a balance structure from disk
+     */
+    public static function fromArray(array $data): self
+    {
+        $balance = new self();
+
+        $balance->current = isset($data['current'])
+            ? unserialize($data['current']) : null;
+        $balance->available = isset($data['available'])
+            ? unserialize($data['available']) : null;
+        $balance->limit = isset($data['limit'])
+            ? unserialize($data['limit']) : null;
+
+        $balance->overdrawn = $data['overdrawn'] ?? null;
+        $balance->currency = $data['currency'] ?? null;
+
+        return $balance;
+    }
+
+    public function getCurrent(): ?Number
+    {
+        return $this->current;
+    }
+
+    public function getAvailable(): ?Number
+    {
+        return $this->available;
+    }
+
+    public function getLimit(): ?Number
+    {
+        return $this->limit;
+    }
+
+    public function getOverdrawn(): ?bool
+    {
+        return $this->overdrawn;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+}

--- a/app/Services/Akahu/Model/Account/Connection.php
+++ b/app/Services/Akahu/Model/Account/Connection.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Account;
+
+final class Connection
+{
+    // The name of the provider.
+    private ?string $name = null;
+
+    // A URL pointing to an image of the provider's logo.
+    private ?string $logo = null;
+
+    // The type of integration used to connect to this institution.
+    // This will be one of:
+    //  - classic: A classic Akahu connection, which uses Akahu's custom built integration
+    //    to connect to the institution.
+    //  - official: An official open banking connection, which uses the institution's
+    //    official open banking APIs.
+    private ?string $connectionType = null;
+
+    /**
+     * Parse a connection structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $connection = new self();
+
+        $connection->name = $json['name'] ?? null;
+        $connection->logo = $json['logo'] ?? null;
+        $connection->connectionType = $json['connection_type'] ?? null;
+
+        return $connection;
+    }
+
+    /**
+     * Serialize a connection structure to store on disk
+     */
+    public function toArray(): array
+    {
+        return array(
+            'name' => $this->name,
+            'logo' => $this->logo,
+            'connectionType' => $this->connectionType,
+        );
+    }
+
+    /**
+     * Deserialize a connection structure from disk
+     */
+    public static function fromArray(array $data): self
+    {
+        $connection = new self();
+
+        $connection->name = $data['name'] ?? null;
+        $connection->logo = $data['logo'] ?? null;
+        $connection->connectionType = $data['connectionType'] ?? null;
+
+        return $connection;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getLogo(): ?string
+    {
+        return $this->logo;
+    }
+
+    public function getConnectionType(): ?string
+    {
+        return $this->connectionType;
+    }
+}

--- a/app/Services/Akahu/Model/Account/Refreshed.php
+++ b/app/Services/Akahu/Model/Account/Refreshed.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Account;
+
+use Carbon\Carbon;
+
+final class Refreshed
+{
+    // When the balance was last updated.
+    private ?Carbon $balance = null;
+
+    // When other account metadata was last updated (any account property
+    // apart from balance).
+    private ?Carbon $meta = null;
+
+    // When we last checked for and processed any new transactions. This
+    // flag may be missing when an account has first connected, as it takes
+    // a few seconds for new transactions to be processed.
+    private ?Carbon $transactions = null;
+
+    // When we last fetched identity data about the party who has
+    // authenticated with the financial institution when connecting this
+    // account. This data is updated by Akahu on a fixed 30 day interval,
+    // regardless of your app's data refresh configuration.
+    private ?Carbon $party = null;
+
+    /**
+     * Parse a refreshed structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $refreshed = new self();
+
+        $refreshed->balance = isset($json['balance'])
+            ? Carbon::parse($json['balance']) : null;
+        $refreshed->meta = isset($json['meta'])
+            ? Carbon::parse($json['meta']) : null;
+        $refreshed->transactions = isset($json['transactions'])
+            ? Carbon::parse($json['transactions']) : null;
+        $refreshed->party = isset($json['party'])
+            ? Carbon::parse($json['party']) : null;
+
+        return $refreshed;
+    }
+
+    /**
+     * Serialize a refreshed structure to store on disk
+     */
+    public function toArray(): array
+    {
+        return array(
+            'balance' => $this->balance?->toISOString(),
+            'meta' => $this->meta?->toISOString(),
+            'transactions' => $this->transactions?->toISOString(),
+            'party' => $this->party?->toISOString(),
+        );
+    }
+
+    /**
+     * Deserialize a refreshed structure from disk
+     */
+    public static function fromArray(array $data): self
+    {
+        $refreshed = new self();
+
+        $refreshed->balance = isset($data['balance'])
+            ? Carbon::parse($data['balance']) : null;
+        $refreshed->meta = isset($data['meta'])
+            ? Carbon::parse($data['meta']) : null;
+        $refreshed->transactions = isset($data['transactions'])
+            ? Carbon::parse($data['transactions']) : null;
+        $refreshed->party = isset($data['party'])
+            ? Carbon::parse($data['party']) : null;
+
+        return $refreshed;
+    }
+
+    public function getBalance(): ?Carbon
+    {
+        return $this->balance;
+    }
+
+    public function getMeta(): ?Carbon
+    {
+        return $this->meta;
+    }
+
+    public function getTransactions(): ?Carbon
+    {
+        return $this->transactions;
+    }
+
+    public function getParty(): ?Carbon
+    {
+        return $this->party;
+    }
+}

--- a/app/Services/Akahu/Model/Transaction/Category.php
+++ b/app/Services/Akahu/Model/Transaction/Category.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Transaction;
+
+use Carbon\Carbon;
+use App\Services\Akahu\Model\Transaction\Meta;
+
+// The base NZFCC category that the transaction belongs to. Also included
+// is a map of less specific category groupings that this NZFCC category
+// is part of (by default Akahu will include personal_finance). Custom
+// category groupings can be configured for your application if required.
+// Only present when you have permission to view enriched transactions.
+final class Category
+{
+    // The NZFCC Category ID
+    private ?string $nzfccId = null;
+
+    // The NZFCC Category Name
+    private ?string $name = null;
+
+    //
+    // Higher level groupings that a category belongs to.
+    //
+
+    private ?PersonalFinanceGroup $personalFinanceGroup = null;
+
+    /**
+     * Parse a category structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $category = new self();
+
+        $category->nzfccId = $json['_id'] ?? null;
+        $category->name = $json['name'] ?? null;
+
+        if (isset($json['groups']) && is_array($json['groups'])) {
+            $category->groups = [];
+
+            if (isset($json['groups'][PersonalFinanceGroup::CLASSIFIER])) {
+                $groupJson = $json['groups'][PersonalFinanceGroup::CLASSIFIER];
+                $category->personalFinanceGroup = PersonalFinanceGroup::fromJson($groupJson);
+            }
+        }
+
+        return $category;
+    }
+
+    public function getNzfccId(): ?string
+    {
+        return $this->nzfccId;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getPersonalFinanceGroup(): ?PersonalFinanceGroup
+    {
+        return $this->personalFinanceGroup;
+    }
+}

--- a/app/Services/Akahu/Model/Transaction/Conversion.php
+++ b/app/Services/Akahu/Model/Transaction/Conversion.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Transaction;
+
+use Carbon\Carbon;
+use App\Support\Facades\Steam;
+use BcMath\Number;
+
+// https://developers.akahu.nz/docs/the-transaction-model#meta
+// If this transaction was made in another currency, details about the currency conversion.
+final class Conversion
+{
+    // The amount transacted in the foreign currency
+    private ?Number $amount = null;
+
+    // The (3 letter ISO 4217 currency code)[https://www.xe.com/iso4217.php]
+    // that was used for this transaction.
+    private ?string $currency = null;
+
+    // The foreign currency conversion rate applied to this transaction.
+    private ?Number $rate = null;
+
+    // Undocumented
+    private ?Number $fee = null;
+
+    /**
+     * Parse a conversion structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $conversion = new self();
+
+        $conversion->amount = isset($json['amount'])
+            ? Steam::bcnumber($json['amount']) : null;
+
+        $conversion->currency = $json['currency'] ?? null;
+
+        $conversion->rate = isset($json['rate'])
+            ? Steam::bcnumber($json['rate']) : null;
+        $conversion->fee = isset($json['fee'])
+            ? Steam::bcnumber($json['fee']) : null;
+
+        return $conversion;
+    }
+
+    public function getAmount(): ?Number
+    {
+        return $this->amount;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    public function getRate(): ?Number
+    {
+        return $this->rate;
+    }
+
+    public function getFee(): ?Number
+    {
+        return $this->fee;
+    }
+}

--- a/app/Services/Akahu/Model/Transaction/Merchant.php
+++ b/app/Services/Akahu/Model/Transaction/Merchant.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Transaction;
+
+use Carbon\Carbon;
+
+// Akahu defines a merchant as the business who was party to this transaction.
+// For example, "The Warehouse" is a merchant.
+final class Merchant
+{
+    // The Akahu Merchant ID
+    private ?string $akahuId = null;
+
+    // The Akahu Merchant name
+    private ?string $name = null;
+
+    // The Akahu Merchant website
+    private ?string $website = null;
+
+    // Undocumented
+    // https://www.nzbn.govt.nz/
+    private ?string $nzbn = null;
+
+    /**
+     * Parse a merchant structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $merchant = new self();
+
+        $merchant->akahuId = $json['_id'] ?? null;
+        $merchant->name = $json['name'] ?? null;
+        $merchant->website = $json['website'] ?? null;
+        $merchant->nzbn = $json['nzbn'] ?? null;
+
+        return $merchant;
+    }
+
+    public function getAkahuId(): ?string
+    {
+        return $this->akahuId;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getWebsite(): ?string
+    {
+        return $this->website;
+    }
+
+    public function getNZBN(): ?string
+    {
+        return $this->nzbn;
+    }
+}

--- a/app/Services/Akahu/Model/Transaction/Meta.php
+++ b/app/Services/Akahu/Model/Transaction/Meta.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Transaction;
+
+use Carbon\Carbon;
+
+// https://developers.akahu.nz/docs/the-transaction-model#meta
+// Additional metadata we manage to retrieve for the transaction. Only present
+// when you have permission to view enriched transactions. All fields are optional
+// and provided on a "best-effort" basis.
+final class Meta
+{
+    // The particulars field set on this transaction.
+    private ?string $particulars = null;
+
+    // The code field set on this transaction.
+    private ?string $code = null;
+
+    // The reference field set on this transaction.
+    private ?string $reference = null;
+
+    // The formatted NZ bank account number of the other party to this transaction
+    private ?string $otherAccount = null;
+
+    // If this transaction was made in another currency, details about the currency conversion.
+    private ?Conversion $conversion = null;
+
+    // If this transaction was made with a credit or debit card, the last four digits of the
+    // card number.
+    private ?string $cardSuffix = null;
+
+    // URL of a .png image for this transaction. This is typically the logo of the transaction
+    // merchant. If no logo is available, a placeholder image is provided.
+    private ?string $logo = null;
+
+    /**
+     * Parse a meta structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $meta = new self();
+
+        $meta->particulars = $json['particulars'] ?? null;
+        $meta->code = $json['code'] ?? null;
+        $meta->reference = $json['reference'] ?? null;
+
+        $meta->otherAccount = $json['other_account'] ?? null;
+
+        $meta->conversion = isset($json['conversion'])
+            ? Conversion::fromJson($json['conversion']) : null;
+
+        $meta->cardSuffix = $json['card_suffix'] ?? null;
+
+        $meta->logo = $json['logo'] ?? null;
+
+        return $meta;
+    }
+
+    public function getParticulars(): ?string
+    {
+        return $this->particulars;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function getReference(): ?string
+    {
+        return $this->reference;
+    }
+
+    public function getOtherAccount(): ?string
+    {
+        return $this->otherAccount;
+    }
+
+    public function getConversion(): ?Conversion
+    {
+        return $this->conversion;
+    }
+
+    public function getCardSuffix(): ?string
+    {
+        return $this->cardSuffix;
+    }
+
+    public function getLogo(): ?string
+    {
+        return $this->logo;
+    }
+}

--- a/app/Services/Akahu/Model/Transaction/PersonalFinanceGroup.php
+++ b/app/Services/Akahu/Model/Transaction/PersonalFinanceGroup.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Transaction;
+
+use Carbon\Carbon;
+use App\Services\Akahu\Model\Transaction\Meta;
+
+final class PersonalFinanceGroup
+{
+    public const CLASSIFIER = 'personal_finance';
+
+    private ?string $akahuId = null;
+    private ?string $name = null;
+
+    /**
+     * Parse a personal finance group structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $personalFinanceGroup = new self();
+
+        $personalFinanceGroup->akahuId = $json['_id'] ?? null;
+        $personalFinanceGroup->name = $json['name'] ?? null;
+
+        return $personalFinanceGroup;
+    }
+
+    public function getAkahuId(): ?string
+    {
+        return $this->akahuId;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/app/Services/Akahu/Model/Transaction/Transaction.php
+++ b/app/Services/Akahu/Model/Transaction/Transaction.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Model\Transaction;
+
+use Carbon\Carbon;
+use App\Services\Akahu\Model\Transaction\Meta;
+use InvalidArgumentException;
+use App\Support\Facades\Steam;
+use BcMath\Number;
+
+final class Transaction
+{
+    // he _id key is a unique identifier for the transaction in the Akahu system.
+    // It is always be prefixed by trans_ so that you can tell that it refers to a transaction.
+    private ?string $akahuId     = null;
+
+    // The _account key indicates which account this transaction belongs to.
+    private ?string $akahuAccountId = null;
+
+    // The time that Akahu first saw this transaction (as an ISO 8601 timestamp). This
+    // is unrelated to the transaction date (when the transaction occurred) because Akahu
+    // may have retrieved an old transaction.
+    private ?Carbon $createdAt     = null;
+
+    // An ISO 8601 timestamp. In many cases this will only be accurate to the day, due
+    // to the level of detail provided by the bank. Where available, the date is the
+    // date that the transaction took place, but if that information is unavailable it
+    // will be the date that the transaction was settled by the bank.
+    private ?Carbon $date     = null;
+
+    // The transacton description as provided by the bank. Some minor cleanup is done
+    // by Akahu (such as whitespace normalisation), but this value is otherwise direct
+    // from the bank.
+    private ?string $description     = null;
+
+    // The amount of money that was moved by this transaction.
+    private ?Number $amount     = null;
+
+    // If available, the account balance immediately after this transaction was made.
+    // This value is direct from the bank and not modified by Akahu.
+    private ?Number $balance     = null;
+
+    // https://developers.akahu.nz/docs/the-transaction-model#type
+    // What sort of transaction this is. Akahu tries to find a specific transaction
+    // type, falling back to "CREDIT" or "DEBIT" if nothing else is available.
+    private ?string $type     = null;
+
+    //
+    // Akahu "Enriched transaction data"
+    //
+
+    // The category object categorises the transaction using NZFCC codes
+    // (New Zealand Financial Category Codes)
+    private ?Category $category = null;
+
+    // Akahu defines a merchant as the business who was party to this transaction. For
+    // example, "The Warehouse" is a merchant.
+    private ?Merchant $merchant = null;
+
+    // https://developers.akahu.nz/docs/the-transaction-model#meta
+    // This is other metadata that we extract from the transaction. All of the meta
+    // fields are optional.
+    private ?Meta $meta = null;
+
+    /**
+     * Parse a transaction structure from an Akahu api json response
+     */
+    public static function fromJson(array $json): self
+    {
+        $transaction = new self();
+
+        $transaction->akahuId = $json['_id'] ?? null;
+        $transaction->akahuAccountId = $json['_account']
+            ?? throw new InvalidArgumentException('transaction contains no account id');
+
+        $createdAt = $json['created_at'] ?? null;
+        $transaction->createdAt = Carbon::parse($createdAt);
+
+        $date = $json['date']
+            ?? throw new InvalidArgumentException('transaction contains no date');
+        $transaction->date = Carbon::parse($date);
+
+        $transaction->description = $json['description']
+            ?? throw new InvalidArgumentException('transaction contains no description');
+        $transaction->amount = isset($json['amount'])
+            ? Steam::bcnumber($json['amount'])
+                : throw new InvalidArgumentException('transaction contains no amount');
+
+        $transaction->balance = isset($json['balance'])
+            ? Steam::bcnumber($json['balance']) : null;
+        $transaction->type = $json['type']
+            ?? throw new InvalidArgumentException('transaction contains no type');
+        $transaction->category = isset($json['category'])
+            ? Category::fromJson($json['category']) : null;
+        $transaction->merchant = isset($json['merchant'])
+            ? Merchant::fromJson($json['merchant']) : null;
+        $transaction->meta = isset($json['meta'])
+            ? Meta::fromJson($json['meta']) : null;
+
+        return $transaction;
+    }
+
+    public function getAkahuId(): ?string
+    {
+        return $this->akahuId;
+    }
+
+    public function getAkahuAccountId(): string
+    {
+        return $this->akahuAccountId;
+    }
+
+    public function getCreatedAt(): ?Carbon
+    {
+        return $this->createdAt;
+    }
+
+    public function getDate(): Carbon
+    {
+        return $this->date;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getAmount(): ?Number
+    {
+        return $this->amount;
+    }
+
+    public function getBalance(): ?Number
+    {
+        return $this->balance;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getCategory(): ?Category
+    {
+        return $this->category;
+    }
+
+    public function getMerchant(): ?Merchant
+    {
+        return $this->merchant;
+    }
+
+    public function getMeta(): ?Meta
+    {
+        return $this->meta;
+    }
+}

--- a/app/Services/Akahu/Request/AkahuDateRange.php
+++ b/app/Services/Akahu/Request/AkahuDateRange.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Request;
+
+use App\Exceptions\ImporterHttpException;
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Response\GetAccountsResponse;
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Shared\Response\Response;
+use GuzzleHttp\Exception\GuzzleException;
+use App\Services\Akahu\Response\GetTransactions\GetTransactionsResponseBuilder;
+use App\Services\Akahu\Response\GetTransactions\GetTransactionsResponse;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+
+final class AkahuDateRange
+{
+    private ?Carbon $dateNotBefore;
+    private ?Carbon $dateNotAfter;
+
+    public function __construct(Configuration $configuration)
+    {
+        $tz = config('app.timezone');
+        $dateNotBefore = null;
+        $dateNotAfter = null;
+
+        if ('' !== $configuration->getDateNotBefore() ?? '') {
+            $dateNotBefore = Carbon::parse($configuration->getDateNotBefore(), $tz);
+        }
+
+        if ('' !== $configuration->getDateNotAfter() ?? '') {
+            $dateNotAfter = Carbon::parse($configuration->getDateNotAfter(), $tz);
+        }
+
+        $this->dateNotBefore = $dateNotBefore;
+        $this->dateNotAfter = $dateNotAfter;
+    }
+
+    public function startDate(): ?Carbon
+    {
+        // https://developers.akahu.nz/docs/accessing-transactional-data#getting-a-date-range
+        // We want to include transactions that fall *on* the `dateNotBefore`
+        // date as well.
+        return $this->dateNotBefore?->copy()?->subMillisecond();
+    }
+
+    public function endDate(): ?Carbon
+    {
+        // The `end` query parameter is inclusive.
+        return $this->dateNotAfter?->copy()?->addDay();
+    }
+}

--- a/app/Services/Akahu/Request/GetAccountsRequest.php
+++ b/app/Services/Akahu/Request/GetAccountsRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Request;
+
+use App\Exceptions\ImporterHttpException;
+use App\Services\Akahu\Response\GetAccountsResponse;
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Shared\Response\Response;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Log;
+
+final class GetAccountsRequest extends Request
+{
+    public function get(): GetAccountsResponse
+    {
+        Log::debug(sprintf('GetAccountsRequest::%s()', __METHOD__));
+        return new GetAccountsResponse($this->authenticatedGet('accounts'));
+    }
+}

--- a/app/Services/Akahu/Request/GetTransactionsRequest.php
+++ b/app/Services/Akahu/Request/GetTransactionsRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Request;
+
+use App\Exceptions\ImporterHttpException;
+use App\Services\Akahu\Response\GetAccountsResponse;
+use App\Services\Akahu\Request\AkahuDateRange;
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Shared\Response\Response;
+use GuzzleHttp\Exception\GuzzleException;
+use App\Services\Akahu\Response\GetTransactions\GetTransactionsResponseBuilder;
+use App\Services\Akahu\Response\GetTransactions\GetTransactionsResponse;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+
+final class GetTransactionsRequest extends Request
+{
+    private string $akahuId;
+    private ?Carbon $startDate;
+    private ?Carbon $endDate;
+    private AkahuDateRange $dateRange;
+
+    public function __construct(
+        string $akahuId,
+        AkahuDateRange $dateRange,
+    )
+    {
+        parent::__construct();
+
+        $this->akahuId = $akahuId;
+        $this->dateRange = $dateRange;
+    }
+
+    public function get(): GetTransactionsResponse
+    {
+        $responseBuilder = new GetTransactionsResponseBuilder();
+        $cursor = null;
+
+        // Akahu's transaction endpoint implements pagination
+        do {
+            // https://developers.akahu.nz/docs/accessing-transactional-data#getting-a-date-range
+            if (null !== $this->dateRange->startDate()) {
+                $this->setQueryParam('start', $this->dateRange->startDate()->toISOString());
+            }
+
+            if (null !== $this->dateRange->endDate()) {
+                $this->setQueryParam('end', $this->dateRange->endDate()->toISOString());
+            }
+
+            if (null !== $cursor) {
+                $this->setQueryParam('cursor', $cursor);
+            }
+
+            $responseJson = $this->authenticatedGet(sprintf(
+                'accounts/%s/transactions',
+                $this->akahuId
+            ));
+
+            $cursor = $responseBuilder->submitPageAndGetNextCursor($responseJson);
+        } while (null !== $cursor);
+
+        return $responseBuilder->build();
+    }
+}

--- a/app/Services/Akahu/Request/Request.php
+++ b/app/Services/Akahu/Request/Request.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Request;
+
+use App\Services\Akahu\Authentication\SecretManager;
+use App\Exceptions\ImporterErrorException;
+use App\Exceptions\ImporterHttpException;
+use Illuminate\Support\Facades\Log;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Client;
+
+abstract class Request
+{
+    private string $appIdToken;
+    private string $userAccessToken;
+    private string $apiBaseUrl;
+    private bool $debug;
+    private array $queryParams = [];
+    private array $historicRequests = [];
+    private HandlerStack $handlerStack;
+    private float $timeOut = 30.0;
+
+    public function __construct()
+    {
+        $this->setDebug(false);
+        $this->setAppIdToken(SecretManager::getAppIdToken());
+        $this->setUserAccessToken(SecretManager::getUserAccessToken());
+        $this->setApiBaseUrl(config('akahu.base_url'));
+
+        if (config('app.debug')) {
+            $this->createHandlerStack();
+        }
+    }
+
+    public final function setAppIdToken(string $token): void
+    {
+        $this->appIdToken = $token;
+    }
+
+    public final function setUserAccessToken(string $token): void
+    {
+        $this->userAccessToken = $token;
+    }
+
+    public final function setApiBaseUrl(string $baseUrl): void
+    {
+        $this->apiBaseUrl = $baseUrl;
+    }
+
+    public final function setRequestTimeout(float $timeOut): void
+    {
+        $this->timeOut = $timeOut;
+    }
+
+    public final function setQueryParam(string $key, string $value): void
+    {
+        $this->queryParams[$key] = $value;
+    }
+
+    public final function setDebug(bool $debug): void
+    {
+        $this->debug = $debug;
+    }
+
+    private function createHandlerStack(): void
+    {
+        $this->handlerStack = HandlerStack::create();
+        $this->handlerStack->push(Middleware::history($this->historicRequests));
+    }
+
+    public final function getHistoricRequests(): array
+    {
+        return $this->historicRequests;
+    }
+
+    protected final function getClient(): Client
+    {
+        return new Client([
+            'connect_timeout' => $this->timeOut,
+            'timeout' => $this->timeOut
+        ]);
+    }
+
+    protected final function authenticatedGet(string $apiPath): array
+    {
+        $apiUrl = sprintf(
+            "%s/%s",
+            $this->apiBaseUrl,
+            $apiPath,
+        );
+
+        $headers = [
+            'Accept'        => 'application/json',
+            'User-Agent'    => sprintf('FF3-data-importer/%s', config('importer.version')),
+            'Authorization' => sprintf('Bearer %s', $this->userAccessToken),
+            'X-Akahu-Id' => $this->appIdToken,
+        ];
+
+        $query = $this->queryParams;
+        $debug = $this->debug;
+
+        $handlerStackName = [];
+
+        if (config('app.debug')) {
+            $handler = $this->handlerStack;
+            $handlerStackName = ['handler'];
+        }
+
+        $client = $this->getClient();
+
+        try {
+            $response = $client->request(
+                'GET',
+                $apiUrl,
+                compact('headers', 'query', 'debug', $handlerStackName)
+            );
+        } catch (ConnectException|TooManyRedirectsException $e) {
+            throw new ImporterErrorException(sprintf(
+                'Failed to connect to the Akahu api (%s): %s',
+                $apiUrl,
+                $e->getMessage()
+            ));
+        } catch (BadResponseException $e) {
+            throw new ImporterHttpException(sprintf(
+                    'Akahu api returned an error response (%s): %s',
+                    $apiUrl,
+                    $e->getMessage()
+                ),
+                $e->getResponse()->getStatusCode(),
+                $e
+            );
+        }
+
+        if (config('app.debug')) {
+            $historicRequests = $this->getHistoricRequests();
+            $lastRequest = end($historicRequests)['request'];
+            Log::debug(sprintf('Fetched from from endpoint "%s"', $lastRequest->getUri()));
+        }
+
+        $json = json_decode((string) $response->getBody(), true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            $msg = sprintf(
+                'Akahu api returned invalid json (%s). See logs for more details.',
+                $apiUrl
+            );
+
+            Log::error($msg . ' json: "' . $response->getBody() . '"');
+
+            throw new ImporterErrorException($msg);
+        }
+
+        return $json;
+    }
+}

--- a/app/Services/Akahu/Response/GetAccountsResponse.php
+++ b/app/Services/Akahu/Response/GetAccountsResponse.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Response;
+
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Shared\Response\Response;
+use Illuminate\Support\Facades\Log;
+use App\Exceptions\ImporterErrorException;
+
+final class GetAccountsResponse extends Response
+{
+    private array $accounts;
+
+    public function __construct(array $json)
+    {
+        if (array_key_exists('success', $json) && $json['success']) {
+            Log::debug('Akahu GetAccountsRequest returned successfully');
+
+            if (array_key_exists('items', $json)) {
+                $this->accounts = array_map(Account::fromJson(...), $json['items']);
+                return;
+            }
+        }
+
+        $msg = 'Akahu api returned badly structured json, expected response to contain';
+        $msg .= ' a "success" attribute and an "items" attribute. See logs for more details.';
+        Log::error($msg . ' json: "' . json_encode($json) . '"');
+
+        throw new ImporterErrorException($msg);
+    }
+
+    public function getAccounts(): array
+    {
+        return $this->accounts;
+    }
+}

--- a/app/Services/Akahu/Response/GetTransactions/GetTransactionsResponse.php
+++ b/app/Services/Akahu/Response/GetTransactions/GetTransactionsResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Response\GetTransactions;
+
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Shared\Response\Response;
+use Illuminate\Support\Facades\Log;
+
+final class GetTransactionsResponse extends Response
+{
+    private array $transactions;
+
+    public function __construct(array $transactions)
+    {
+        $this->transactions = $transactions;
+    }
+
+    public function getTransactions(): array
+    {
+        return $this->transactions;
+    }
+}

--- a/app/Services/Akahu/Response/GetTransactions/GetTransactionsResponseBuilder.php
+++ b/app/Services/Akahu/Response/GetTransactions/GetTransactionsResponseBuilder.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Response\GetTransactions;
+
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Akahu\Model\Transaction\Transaction;
+use App\Services\Shared\Response\Response;
+use Illuminate\Support\Facades\Log;
+use App\Exceptions\ImporterErrorException;
+
+final class GetTransactionsResponseBuilder
+{
+    public array $transactions = [];
+
+    public function submitPageAndGetNextCursor(array $json): ?string
+    {
+        if (array_key_exists('success', $json)) {
+            if (!$json['success']) {
+                $msg = 'Akahu api returned a success value of "false". See logs for more details';
+                Log::error($msg . ' json: "' . json_encode($json) . '"');
+
+                throw new ImporterErrorException($msg);
+            }
+
+            Log::debug('Akahu GetTransactionsRequest returned successfully');
+
+            if (array_key_exists('items', $json)) {
+                $this->submitPage($json['items']);
+            }
+
+            if (array_key_exists('cursor', $json) && array_key_exists('next', $json['cursor'])) {
+                $nextCursor = $json['cursor']['next'];
+
+                Log::debug(sprintf(
+                    'Akahu api returned a page with a next cursor: %s',
+                    $nextCursor
+                ));
+
+                return $nextCursor;
+            }
+
+            return null;
+        }
+
+        $msg = 'Akahu api returned badly structured json, expected response to contain';
+        $msg .= ' a "success" attribute and an "items" attribute. See logs for more details.';
+        Log::error($msg . ' json: "' . json_encode($json) . '"');
+
+        throw new ImporterErrorException($msg);
+    }
+
+    private function submitPage(array $transactionsJson)
+    {
+        $pageTransactions = array_map(Transaction::fromJson(...), $transactionsJson);
+        array_push($this->transactions, ...$pageTransactions);
+    }
+
+    public function build(): GetTransactionsResponse
+    {
+        return new GetTransactionsResponse($this->transactions);
+    }
+}

--- a/app/Services/Akahu/Validation/NewJobDataCollector.php
+++ b/app/Services/Akahu/Validation/NewJobDataCollector.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Akahu\Validation;
+
+use App\Services\Shared\Validation\NewJobDataCollectorInterface;
+use App\Services\Akahu\Request\GetAccountsRequest;
+use App\Exceptions\ImporterHttpException;
+use App\Exceptions\ImporterErrorException;
+use App\Models\ImportJob;
+use Illuminate\Support\MessageBag;
+use App\Services\Akahu\Model\Account\Account;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+final class NewJobDataCollector implements NewJobDataCollectorInterface
+{
+    private ImportJob $importJob;
+
+    public function collectAccounts(): MessageBag
+    {
+        $messages = new MessageBag();
+        $request = new GetAccountsRequest();
+
+        try {
+            $response = $request->get();
+        } catch (ImporterHttpException $e) {
+            if (SymfonyResponse::HTTP_UNAUTHORIZED === $e->getCode()) {
+                // Start a reauthentication flow
+                session()->put('akahu_reauthenticate', 'true');
+
+                $msg = 'Akahu credentials could not be authenticated, either the access tokens provided are invalid or have been revoked. You can try authenticating again or see the logs for more infomation.';
+
+                $messages->add('no_accounts', $msg);
+                Log::error($msg . ' | ' . $e->getMessage());
+
+                return $messages;
+            }
+
+            if (SymfonyResponse::HTTP_FORBIDDEN === $e->getCode()) {
+                // Start a reauthentication flow
+                session()->put('akahu_reauthenticate', 'true');
+
+                $msg = 'Akahu returned Forbidden when using the provided credentials, make sure all necessary permissions are granted in the Akahu website. You can try authenticating again or see the logs for more infomation.';
+
+                $messages->add('no_accounts', $msg);
+                Log::error($msg . ' | ' . $e->getMessage());
+
+                return $messages;
+            }
+
+            throw new ImporterErrorException(sprintf(
+                "Failed get account details from the Akahu api: %s",
+                $e->getMessage()
+            ));
+        }
+
+        $this->importJob->setServiceAccounts($response->getAccounts());
+
+        return $messages;
+    }
+
+    public function validate(): MessageBag
+    {
+        return new MessageBag();
+    }
+
+    public function getImportJob(): ImportJob
+    {
+        return $this->importJob;
+    }
+
+    public function setImportJob(ImportJob $importJob): void
+    {
+        $this->importJob = $importJob;
+    }
+
+    public function getFlowName(): string
+    {
+        return 'akahu';
+    }
+}

--- a/app/Services/Shared/Conversion/ConversionRoutineFactory.php
+++ b/app/Services/Shared/Conversion/ConversionRoutineFactory.php
@@ -34,6 +34,7 @@ use App\Services\Nordigen\Conversion\RoutineManager as NordigenRoutineManager;
 use App\Services\Shared\File\FileContentSherlock;
 use App\Services\SimpleFIN\Conversion\RoutineManager as SimpleFINRoutineManager;
 use App\Services\Sophtron\Conversion\RoutineManager as SophtronRoutineManager;
+use App\Services\Akahu\Conversion\RoutineManager as AkahuRoutineManager;
 use Illuminate\Support\Facades\Log;
 
 final class ConversionRoutineFactory
@@ -84,6 +85,9 @@ final class ConversionRoutineFactory
         }
         if ('eb' === $flow) {
             return new EnableBankingRoutineManager($this->importJob);
+        }
+        if ('akahu' === $flow) {
+            return new AkahuRoutineManager($this->importJob);
         }
 
         throw new ImporterErrorException(sprintf('ConversionRoutineFactory cannot create a routine for import flow "%s"', $flow));

--- a/app/Services/Shared/Conversion/CreatesAccounts.php
+++ b/app/Services/Shared/Conversion/CreatesAccounts.php
@@ -28,6 +28,7 @@ use App\Exceptions\ImporterErrorException;
 use App\Repository\ImportJob\ImportJobRepository;
 use App\Services\EnableBanking\Model\Account as EnableBankingAccount;
 use App\Services\Nordigen\Model\Account as NordigenAccount;
+use App\Services\Akahu\Model\Account\Account as AkahuAccount;
 use App\Services\Shared\Model\ImportServiceAccount;
 use Carbon\Carbon;
 use GrumpyDictator\FFIIIApiSupport\Model\Account;
@@ -75,6 +76,9 @@ trait CreatesAccounts
             }
             if ($entry instanceof EnableBankingAccount) {
                 return $entry->getUid() === $importServiceId;
+            }
+            if ($entry instanceof AkahuAccount) {
+                return $entry->getAkahuId() === $importServiceId;
             }
             Log::debug(sprintf('Class of existing entry is %s', $entry::class));
 

--- a/app/Services/Shared/Conversion/Field.php
+++ b/app/Services/Shared/Conversion/Field.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Shared\Conversion;
+
+final class Field
+{
+    private ?string $fieldName;
+    private $field;
+
+    public function __construct(string $fieldName, $field)
+    {
+        $this->fieldName = $fieldName;
+        $this->field = $field;
+   }
+
+    public function renderIfPresent(string $notes): string
+    {
+        if ($this->present()) {
+            $notes .= sprintf(" - %s: %s\n", $this->fieldName, $this->field);
+        }
+
+        return $notes;
+    }
+
+    public function present(): bool
+    {
+        return !is_null($this->field);
+    }
+}

--- a/app/Services/Shared/Conversion/NoteBuilder.php
+++ b/app/Services/Shared/Conversion/NoteBuilder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Shared\Conversion;
+
+abstract class NoteBuilder
+{
+    private const string SECTION_HEADER_SIZE = '####';
+
+    private string $notes = '';
+
+    public function getNotes(): string
+    {
+        return $this->notes;
+    }
+
+    protected final function renderSection(string $fieldTitle, array $fields)
+    {
+        if (!array_any($fields, fn(Field $f) => $f->present())) {
+            return;
+        }
+
+        $section = '';
+
+        foreach ($fields as $field) {
+            $section = $field->renderIfPresent($section);
+        }
+
+        if ('' !== $section) {
+            $this->notes .= sprintf("%s %s\n%s\n",
+                self::SECTION_HEADER_SIZE,
+                $fieldTitle,
+                $section
+            );
+        }
+    }
+
+    /**
+     * Builds notes on this transaction to give to Firefly III
+     */
+    abstract public function build(): string;
+}

--- a/app/Services/Shared/Model/ImportServiceAccount.php
+++ b/app/Services/Shared/Model/ImportServiceAccount.php
@@ -32,6 +32,9 @@ use App\Services\Nordigen\Model\Account as NordigenAccount;
 use App\Services\Nordigen\Model\Balance;
 use App\Services\SimpleFIN\Model\Account as SimpleFinAccount;
 use App\Services\Sophtron\Model\UserInstitutionAccount as SophtronAccount;
+use App\Services\Akahu\Model\Account\Account as AkahuAccount;
+use App\Support\Facades\Steam;
+
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 
@@ -167,6 +170,25 @@ final class ImportServiceAccount
                     'Currency'          => $account->balanceCurrency,
                     'IBAN'              => $iban,
                     'BBAN'              => $account->accountNumber,
+                ],
+            ]);
+        }
+        if ($account instanceof AkahuAccount) {
+            return self::fromArray([
+                'id'            => $account->getAkahuId(),
+                'name'          => $account->getName(),
+                'currency_code' => $account->getBalance()?->getCurrency(),
+                'status'        => $account->getFireflyStatus(),
+                'bban'          => $account->getFormattedAccount() ?? '',
+                'extra'         => [
+                    'Balance'           => (string) $account->getBalance()?->getCurrent(),
+                    'Organization Name' => $account->getConnection()?->getName(),
+                    'Balance date' => $account->getRefreshed()
+                        ?->getBalance()
+                        ?->copy()
+                        ->setTimezone(config('app.timezone'))
+                        ->format('Y-m-d H:i:s'),
+                    'Account Type' => $account->getType(),
                 ],
             ]);
         }
@@ -370,6 +392,43 @@ final class ImportServiceAccount
                 $key                  = sprintf('Balance (%s) (%s)', $balance['balance_type'] ?? 'unknown', $balance['currency'] ?? '');
                 $current->extra[$key] = $balance['amount'] ?? '';
             }
+            $return[] = $current;
+        }
+
+        return $return;
+    }
+
+    public static function convertAkahuArray(array $accounts): array
+    {
+        Log::debug(sprintf('[%s] Now in %s', config('importer.version'), __METHOD__));
+        $return = [];
+
+        foreach ($accounts as $account) {
+            $current = self::fromArray([
+                'id'            => $account->getAkahuId(),
+                'name'          => $account->getName(),
+                'currency_code' => $account->getBalance()?->getCurrency(),
+                'status'        => $account->getFireflyStatus(),
+                'bban'          => $account->getFormattedAccount() ?? '',
+                'extra'         => [
+                    // FIXME: pull dp from api
+                    'Current Balance' => Steam::bcstringify(
+                        $account->getBalance()?->getCurrent(),
+                        2
+                    ),
+                    'Balance date' => $account->getRefreshed()
+                        ?->getBalance()
+                        ?->copy()
+                        ->setTimezone(config('app.timezone'))
+                        ->format('Y-m-d H:i:s'),
+                    'Account Type' => $account->getType(),
+                ],
+            ]);
+
+            $current->org = [
+                'name' => $account->getConnection()?->getName(),
+            ];
+
             $return[] = $current;
         }
 

--- a/app/Support/Steam.php
+++ b/app/Support/Steam.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace App\Support;
 
 use Illuminate\Support\Facades\Log;
+use BcMath\Number;
 use ValueError;
 
 /**
@@ -173,5 +174,49 @@ final class Steam
         }
 
         return $amount;
+    }
+
+    /**
+     * https://github.com/firefly-iii/firefly-iii/blob/15fef8bbb5a31993/app/Support/Steam.php#L173-L199
+     */
+    public function bcround(?string $number, int $precision = 0): string
+    {
+        if (null === $number) {
+            return '0';
+        }
+        if ('' === trim($number)) {
+            return '0';
+        }
+        // if the number contains "E", it's in scientific notation, so we need to convert it to a normal number first.
+        if (false !== stripos($number, 'e')) {
+            $number = sprintf('%.12f', $number);
+        }
+
+        // Log::debug(sprintf('Trying bcround("%s",%d)', $number, $precision));
+        if (str_contains($number, '.')) {
+            if ('-' !== $number[0]) {
+                return bcadd($number, '0.'.str_repeat('0', $precision).'5', $precision);
+            }
+
+            return bcsub($number, '0.'.str_repeat('0', $precision).'5', $precision);
+        }
+
+        return $number;
+    }
+
+    /**
+     * Store amounts with full `bcscale()` precision.
+     */
+    public function bcnumber(string $number): Number
+    {
+        return new Number(bcround($number, bcscale()));
+    }
+
+    /**
+     * When displaying amounts, use currency specific precision.
+     */
+    public function bcstringify(Number $number, int $currencyDecimalPlaces)
+    {
+        return bcround((string) $number, $currencyDecimalPlaces);
     }
 }

--- a/config/akahu.php
+++ b/config/akahu.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'app_id_token'             => env('AKAHU_APP_ID_TOKEN', ''),
+    'user_access_token'        => env('AKAHU_USER_ACCESS_TOKEN', ''),
+    'base_url'                 => env('AKAHU_BASE_URL', 'https://api.akahu.io/v1')
+];

--- a/config/importer.php
+++ b/config/importer.php
@@ -139,6 +139,13 @@ return [
             'explanation'               => '',
             'supports_new_accounts'     => true,
         ],
+        'akahu'        => [
+            'title'                     => 'Akahu',
+            'enabled'                   => true,
+            'conversion_before_mapping' => true,
+            'explanation'               => '',
+            'supports_new_accounts'     => true,
+        ],
     ],
 
     // docker build info.

--- a/resources/lang/en/import.php
+++ b/resources/lang/en/import.php
@@ -61,6 +61,9 @@ return [
     'placeholder_eb_private_key'    => 'Enable Banking Private Key (PEM format)',
     'help_eb_private_key'           => 'Paste your Enable Banking private key in PEM format',
 
+    'label_akahu_app_id_token'      => 'App ID Token',
+    'label_akahu_user_access_token' => 'User Access Token',
+
     // column roles for CSV import:
     'column__ignore'                => '(ignore this column)',
     'column_account-iban'           => 'Asset account (IBAN)',

--- a/tests/Feature/Akahu/HttpFlowTest.php
+++ b/tests/Feature/Akahu/HttpFlowTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Akahu;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use App\Models\ImportJob;
+use Tests\TestCase;
+
+final class HttpFlowTest extends TestCase
+{
+    public function testValidate(): void
+    {
+        $this
+            ->get('/api/import-flows/validate/akahu')
+            ->assertStatus(200)
+            ->assertJson([
+                'result' => 'OK',
+            ]);
+    }
+
+    public function testGetNewImport(): void
+    {
+        $this
+            ->get('/new-import/akahu')
+            ->assertStatus(200);
+    }
+
+    public function testPostNewImport(): void
+    {
+        Storage::fake('import-jobs');
+
+        $response = $this->post('/new-import/akahu');
+
+        $disk = Storage::disk('import-jobs');
+        $files = $disk->files();
+
+        $this->assertEquals(count($files), 1);
+        $importJobFilename = $files[0];
+
+        $importJobJson = $disk->get($importJobFilename);
+        $this->assertNotEquals($importJobJson, null);
+        $this->assertNotEquals($importJobJson, '');
+        $importJob = ImportJob::createFromJson($importJobJson);
+
+        $this->assertEquals($importJob->getFlow(), 'akahu');
+        $this->assertEquals($importJob->getState(), 'contains_content');
+
+        $response->assertRedirectToRoute('configure-import.index', [
+            $importJob->identifier
+        ]);
+    }
+
+    // TODO: Mock Akahu api responses
+}

--- a/tests/Feature/Akahu/ReauthTest.php
+++ b/tests/Feature/Akahu/ReauthTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Akahu;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Config;
+use App\Models\ImportJob;
+use Tests\TestCase;
+use App\Services\Akahu\Authentication\SecretManager;
+
+final class ReauthTest extends TestCase
+{
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set(sprintf('akahu.%s', SecretManager::APP_ID_TOKEN), 'my personal app');
+        Config::set(sprintf('akahu.%s', SecretManager::USER_ACCESS_TOKEN), 'wrong :(');
+    }
+
+    public function testReauthenticate(): void
+    {
+        Storage::fake('import-jobs');
+        $response = $this->post('/new-import/akahu');
+        $disk = Storage::disk('import-jobs');
+        $importJob = ImportJob::createFromJson($disk->get($disk->files()[0]));
+
+        $response = $this->get(sprintf('/configure-import/%s?parse=true', $importJob->identifier));
+        $this->assertEquals(session('akahu_reauthenticate'), 'true');
+        $this->assertStringContainsString('Akahu credentials could not be authenticated', session('error'));
+
+        $response->assertRedirectToRoute('authenticate-flow.index', [
+            'flow' => 'akahu',
+        ]);
+    }
+}

--- a/tests/Unit/Services/Akahu/Conversion/AkahuNoteBuilderTest.php
+++ b/tests/Unit/Services/Akahu/Conversion/AkahuNoteBuilderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Conversion;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\Meta;
+use App\Services\Akahu\Model\Transaction\Transaction;
+use App\Services\Akahu\Conversion\AkahuNoteBuilder;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+final class AkahuNoteBuilderTest extends TestCase
+{
+    public function testBuildNoteFull(): void
+    {
+        $json = '{
+          "_id": "trans_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_account": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_user": "user_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_connection": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "created_at": "2003-07-30T22:48:42+00:00",
+          "updated_at": "1998-11-22T11:41:08+00:00",
+          "date": "2010-12-07T10:02:08+00:00",
+          "description": "Quic Broadba Card number: aaaa **** **** aaaa",
+          "amount": -71,
+          "balance": 100,
+          "type": "EFTPOS",
+          "hash": "acc_aaaaaaaaaaaaaaaaaaaaaaaar-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "meta": {
+            "particulars": "my particulars",
+            "code": "my code",
+            "reference": "my ref",
+
+            "other_account": "00-0000-0000000-00",
+
+            "conversion": {
+              "amount": 2.15,
+              "currency": "GBP",
+              "rate": 0.49
+            },
+
+            "card_suffix": "1234",
+            "logo": "https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          "merchant": {
+            "_id": "merchant_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "Quic Broadband",
+            "website": "https://www.quic.nz"
+          },
+          "category": {
+            "_id": "nzfcc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "Internet services",
+            "groups": {
+              "personal_finance": {
+                "_id": "group_aaaaaaaaaaaaaaaaaaaaaaaaa",
+                "name": "Utilities"
+              }
+            }
+          }
+        }';
+
+        $transaction = Transaction::fromJson(json_decode($json, true));
+
+        $noteBuilder = new AkahuNoteBuilder($transaction);
+
+        $this->assertSame($noteBuilder->build(), '#### Transaction Metadata
+ - Particulars: my particulars
+ - Code: my code
+ - Reference: my ref
+ - Other account: 00-0000-0000000-00
+
+#### Eftpos Infomation
+ - Card Suffix: 1234
+ - Logo: https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa
+
+#### Merchant Infomation
+ - Name: Quic Broadband
+ - Website: https://www.quic.nz
+
+#### Akahu NZFCC classification (https://nzfcc.org/)
+ - Name: Internet services
+ - Personal finance category: Utilities
+
+');
+    }
+
+    public function testBuildNotePartial(): void
+    {
+        $json = '{
+          "_id": "trans_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_account": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "date": "2010-12-07T10:02:08+00:00",
+          "description": "Quic Broadba Card number: aaaa **** **** aaaa",
+          "amount": -71,
+          "type": "EFTPOS",
+          "meta": {
+            "particulars": "my particulars",
+            "other_account": "00-0000-0000000-00"
+          }
+        }';
+
+        $transaction = Transaction::fromJson(json_decode($json, true));
+
+        $noteBuilder = new AkahuNoteBuilder($transaction);
+
+        $this->assertSame($noteBuilder->build(), '#### Transaction Metadata
+ - Particulars: my particulars
+ - Other account: 00-0000-0000000-00
+
+');
+    }
+}

--- a/tests/Unit/Services/Akahu/Model/Account/AccountTest.php
+++ b/tests/Unit/Services/Akahu/Model/Account/AccountTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Account;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Account\Account;
+use App\Services\Akahu\Model\Account\Connection;
+use App\Services\Akahu\Model\Account\Refreshed;
+use App\Services\Akahu\Model\Account\Balance;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+final class AccountTest extends TestCase
+{
+    public function testSerializeDeserializeFull(): void
+    {
+        $json = '{
+          "_id": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_authorisation": "authorisation_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_credentials": "creds_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "connection": {
+            "_id": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "my bank",
+            "logo": "https://my-bank.com/logos/logo1",
+            "connection_type": "official"
+          },
+          "name": "Business Account",
+          "formatted_account": "99-9999-0000000-00",
+          "status": "ACTIVE",
+          "type": "CHECKING",
+          "meta": {},
+          "attributes": [
+            "PAYMENT_FROM",
+            "PAYMENT_TO"
+          ],
+          "balance": {
+            "current": 100000,
+            "available": 100000,
+            "limit": 10000,
+            "overdrawn": false,
+            "currency": "NZD"
+          },
+          "refreshed": {
+            "balance": "2026-08-05T03:22:25.542Z",
+            "meta": "2026-08-04T03:22:25.542Z",
+            "transactions": "2026-08-03T03:22:29.023Z",
+            "party": "2026-08-02T10:22:29.023Z"
+          },
+          "attributes": [
+            "PAYMENT_TO",
+            "PAYMENT_FROM",
+            "TRANSACTIONS"
+          ]
+        }';
+
+        $original = Account::fromJson(json_decode($json, true));
+
+        $serialized = json_encode($original->toArray(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $deserialized = Account::fromArray(json_decode($serialized, true));
+
+        $this->assertEquals($original, $deserialized);
+    }
+
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "_id": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_authorisation": "authorisation_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_credentials": "creds_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "connection": {
+            "_id": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "my bank",
+            "logo": "https://my-bank.com/logos/logo1",
+            "connection_type": "official"
+          },
+          "name": "Business Account",
+          "formatted_account": "99-9999-0000000-00",
+          "status": "ACTIVE",
+          "type": "CHECKING",
+          "meta": {},
+          "attributes": [
+            "PAYMENT_FROM",
+            "PAYMENT_TO"
+          ],
+          "balance": {
+            "current": 100000,
+            "available": 100000,
+            "limit": 10000,
+            "overdrawn": false,
+            "currency": "NZD"
+          },
+          "refreshed": {
+            "balance": "2026-08-05T03:22:25.542Z",
+            "meta": "2026-08-04T03:22:25.542Z",
+            "transactions": "2026-08-03T03:22:29.023Z",
+            "party": "2026-08-02T10:22:29.023Z"
+          },
+          "attributes": [
+            "PAYMENT_TO",
+            "PAYMENT_FROM",
+            "TRANSACTIONS"
+          ]
+        }';
+
+        $account = Account::fromJson(json_decode($json, true));
+
+        $this->assertEquals($account->getAkahuId(), 'acc_aaaaaaaaaaaaaaaaaaaaaaaaa');
+
+        $this->assertEquals($account->getConnection()?->getName(), 'my bank');
+        $this->assertEquals($account->getConnection()?->getLogo(), 'https://my-bank.com/logos/logo1');
+        $this->assertEquals($account->getConnection()?->getConnectionType(), 'official');
+
+        $this->assertEquals($account->getName(), 'Business Account');
+        $this->assertEquals($account->getAkahuStatus(), 'ACTIVE');
+        $this->assertEquals($account->getFormattedAccount(), '99-9999-0000000-00');
+        $this->assertEquals($account->getMeta(), []);
+
+        $this->assertEquals($account->getRefreshed()?->getBalance(), Carbon::parse('2026-08-05T03:22:25.542Z'));
+        $this->assertEquals($account->getRefreshed()?->getMeta(), Carbon::parse('2026-08-04T03:22:25.542Z'));
+        $this->assertEquals($account->getRefreshed()?->getTransactions(), Carbon::parse('2026-08-03T03:22:29.023Z'));
+        $this->assertEquals($account->getRefreshed()?->getParty(), Carbon::parse('2026-08-02T10:22:29.023Z'));
+
+        $this->assertEquals($account->getType(), 'CHECKING');
+        $this->assertEquals($account->getAttributes(), [
+            Account::ATTRIBUTE_PAYMENT_TO,
+            Account::ATTRIBUTE_PAYMENT_FROM,
+            Account::ATTRIBUTE_TRANSACTIONS,
+        ]);
+    }
+
+    public function testParseJson1(): void
+    {
+
+        $json = '{
+          "_id": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_authorisation": "authorisation_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_credentials": "creds_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "connection": {
+            "_id": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "Demo Bank",
+            "logo": "https://cdn.akahu.nz/logos/connections/conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "connection_type": "official"
+          },
+          "name": "Business Account",
+          "formatted_account": "99-9999-0000000-00",
+          "status": "ACTIVE",
+          "type": "CHECKING",
+          "attributes": [
+            "PAYMENT_FROM",
+            "PAYMENT_TO"
+          ],
+          "balance": {
+            "currency": "NZD",
+            "current": 100000,
+            "available": 100000,
+            "limit": 10000
+          },
+          "refreshed": {
+            "balance": "2026-08-05T10:15:45.863Z",
+            "meta": "2026-08-05T10:15:45.863Z"
+          }
+        }';
+
+        $account = Account::fromJson(json_decode($json, true));
+
+        $this->assertEquals($account->getAkahuId(), 'acc_aaaaaaaaaaaaaaaaaaaaaaaaa');
+
+        $this->assertEquals($account->getConnection()?->getName(), 'Demo Bank');
+        $this->assertEquals($account->getConnection()?->getLogo(), 'https://cdn.akahu.nz/logos/connections/conn_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertEquals($account->getConnection()?->getConnectionType(), 'official');
+
+        $this->assertEquals($account->getName(), 'Business Account');
+        $this->assertEquals($account->getAkahuStatus(), 'ACTIVE');
+        $this->assertEquals($account->getFormattedAccount(), '99-9999-0000000-00');
+        $this->assertEquals($account->getMeta(), null);
+
+        $this->assertEquals($account->getRefreshed()?->getBalance(), Carbon::parse('2026-08-05T10:15:45.863Z'));
+        $this->assertEquals($account->getRefreshed()?->getMeta(), Carbon::parse('2026-08-05T10:15:45.863Z'));
+        $this->assertEquals($account->getRefreshed()?->getTransactions(), null);
+        $this->assertEquals($account->getRefreshed()?->getParty(), null);
+
+        $this->assertEquals($account->getType(), 'CHECKING');
+        $this->assertEquals($account->getAttributes(), [
+            Account::ATTRIBUTE_PAYMENT_FROM,
+            Account::ATTRIBUTE_PAYMENT_TO,
+        ]);
+    }
+
+    public function testParseJson2(): void
+    {
+
+        $json = '{
+          "_id": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_authorisation": "authorisation_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_credentials": "creds_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "connection": {
+            "_id": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "ANZ",
+            "logo": "https://cdn.akahu.nz/logos/connections/conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "connection_type": "official"
+          },
+          "name": "my account",
+          "formatted_account": "11-0000-1111111-00",
+          "status": "ACTIVE",
+          "type": "CHECKING",
+          "attributes": [
+            "PAYMENT_TO",
+            "PAYMENT_FROM",
+            "TRANSACTIONS"
+          ],
+          "balance": {
+            "currency": "NZD",
+            "current": 111.99
+          },
+          "refreshed": {
+            "balance": "2026-08-05T03:22:25.542Z",
+            "meta": "2026-08-05T03:22:25.542Z",
+            "transactions": "2026-08-05T03:22:29.023Z"
+          }
+        }';
+
+        $account = Account::fromJson(json_decode($json, true));
+
+        $this->assertEquals($account->getAkahuId(), 'acc_aaaaaaaaaaaaaaaaaaaaaaaaa');
+
+        $this->assertEquals($account->getConnection()?->getName(), 'ANZ');
+        $this->assertEquals($account->getConnection()?->getLogo(), 'https://cdn.akahu.nz/logos/connections/conn_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertEquals($account->getConnection()?->getConnectionType(), 'official');
+
+        $this->assertEquals($account->getName(), 'my account');
+        $this->assertEquals($account->getAkahuStatus(), 'ACTIVE');
+        $this->assertEquals($account->getFormattedAccount(), '11-0000-1111111-00');
+        $this->assertEquals($account->getMeta(), null);
+
+        $this->assertEquals($account->getRefreshed()?->getBalance(), Carbon::parse('2026-08-05T03:22:25.542Z'));
+        $this->assertEquals($account->getRefreshed()?->getMeta(), Carbon::parse('2026-08-05T03:22:25.542Z'));
+        $this->assertEquals($account->getRefreshed()?->getTransactions(), Carbon::parse('2026-08-05T03:22:29.023Z'));
+        $this->assertEquals($account->getRefreshed()?->getParty(), null);
+
+        $this->assertEquals($account->getType(), 'CHECKING');
+        $this->assertEquals($account->getAttributes(), [
+            Account::ATTRIBUTE_PAYMENT_TO,
+            Account::ATTRIBUTE_PAYMENT_FROM,
+            Account::ATTRIBUTE_TRANSACTIONS,
+        ]);
+    }
+}

--- a/tests/Unit/Services/Akahu/Model/Account/BalanceTest.php
+++ b/tests/Unit/Services/Akahu/Model/Account/BalanceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Account;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Account\Balance;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Log;
+use Override;
+use Tests\TestCase;
+use BcMath\Number;
+
+final class BalanceTest extends TestCase
+{
+    public function testSerializeDeserializeFull(): void
+    {
+        $json = '{
+          "current": 100000,
+          "available": 100000,
+          "limit": 10000,
+          "overdrawn": false,
+          "currency": "NZD"
+        }';
+
+        $original = Balance::fromJson(json_decode($json, true));
+
+        $serialized = json_encode($original->toArray(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $deserialized = Balance::fromArray(json_decode($serialized, true));
+
+        $this->assertEquals($original, $deserialized);
+    }
+
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "current": 100000,
+          "available": 100000,
+          "limit": 10000,
+          "overdrawn": false,
+          "currency": "NZD"
+        }';
+
+        $balance = Balance::fromJson(json_decode($json, true));
+
+        $this->assertEquals($balance->getCurrent(), new Number("100000"));
+        $this->assertEquals($balance->getAvailable(), new Number("100000"));
+        $this->assertEquals($balance->getLimit(), new Number("10000"));
+        $this->assertEquals($balance->getOverdrawn(), false);
+        $this->assertEquals($balance->getCurrency(), 'NZD');
+    }
+
+    public function testParseJson1(): void
+    {
+        $json = '{
+          "currency": "NZD",
+          "current": 100000,
+          "available": 100000,
+          "limit": 10000
+        }';
+
+        $balance = Balance::fromJson(json_decode($json, true));
+
+        $this->assertEquals($balance->getCurrent(), new Number("100000"));
+        $this->assertEquals($balance->getAvailable(), new Number("100000"));
+        $this->assertEquals($balance->getLimit(), new Number("10000"));
+        $this->assertEquals($balance->getOverdrawn(), null);
+        $this->assertEquals($balance->getCurrency(), 'NZD');
+    }
+
+    public function testParseJson2(): void
+    {
+        $json = '{
+          "currency": "NZD",
+          "current": -5500,
+          "available": 4500,
+          "limit": 10000
+        }';
+
+        $balance = Balance::fromJson(json_decode($json, true));
+
+        $this->assertEquals($balance->getCurrent(), new Number("-5500"));
+        $this->assertEquals($balance->getAvailable(), new Number("4500"));
+        $this->assertEquals($balance->getLimit(), new Number("10000"));
+        $this->assertEquals($balance->getOverdrawn(), null);
+        $this->assertEquals($balance->getCurrency(), 'NZD');
+    }
+}

--- a/tests/Unit/Services/Akahu/Model/Account/ConnectionTest.php
+++ b/tests/Unit/Services/Akahu/Model/Account/ConnectionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Account;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Account\Connection;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+final class ConnectionTest extends TestCase
+{
+    public function testSerializeDeserializeFull(): void
+    {
+        $json = '{
+            "_id": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "my bank",
+            "logo": "https://my-bank.com/logos/logo1",
+            "connection_type": "official"
+        }';
+
+        $original = Connection::fromJson(json_decode($json, true));
+
+        $serialized = json_encode($original->toArray(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $deserialized = Connection::fromArray(json_decode($serialized, true));
+
+        $this->assertEquals($original, $deserialized);
+    }
+
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+            "_id": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "my bank",
+            "logo": "https://my-bank.com/logos/logo1",
+            "connection_type": "official"
+        }';
+
+        $connection = Connection::fromJson(json_decode($json, true));
+
+        $this->assertSame($connection->getName(), 'my bank');
+        $this->assertSame($connection->getLogo(), 'https://my-bank.com/logos/logo1');
+        $this->assertSame($connection->getConnectionType(), 'official');
+    }
+
+    public function testParseJson1(): void
+    {
+        $json = '{
+          "_id": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "name": "Demo Bank",
+          "logo": "https://cdn.akahu.nz/logos/connections/conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "connection_type": "official"
+        }';
+
+        $connection = Connection::fromJson(json_decode($json, true));
+
+        $this->assertSame($connection->getName(), 'Demo Bank');
+        $this->assertSame($connection->getLogo(), 'https://cdn.akahu.nz/logos/connections/conn_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertSame($connection->getConnectionType(), 'official');
+    }
+}

--- a/tests/Unit/Services/Akahu/Model/Account/RefreshedTest.php
+++ b/tests/Unit/Services/Akahu/Model/Account/RefreshedTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Account;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Account\Refreshed;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+final class RefreshedTest extends TestCase
+{
+    public function testSerializeDeserializeFull(): void
+    {
+        $json = '{
+          "balance": "2026-08-05T03:22:25.542Z",
+          "meta": "2026-08-04T03:22:25.542Z",
+          "transactions": "2026-08-03T03:22:29.023Z",
+          "party": "2026-08-02T10:22:29.023Z"
+        }';
+
+        $original = Refreshed::fromJson(json_decode($json, true));
+
+        $serialized = json_encode($original->toArray(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $deserialized = Refreshed::fromArray(json_decode($serialized, true));
+
+        $this->assertEquals($original, $deserialized);
+    }
+
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "balance": "2026-08-05T03:22:25.542Z",
+          "meta": "2026-08-04T03:22:25.542Z",
+          "transactions": "2026-08-03T03:22:29.023Z",
+          "party": "2026-08-02T10:22:29.023Z"
+        }';
+
+        $refreshed = Refreshed::fromJson(json_decode($json, true));
+
+        $this->assertEquals($refreshed->getBalance(), Carbon::parse('2026-08-05T03:22:25.542Z'));
+        $this->assertEquals($refreshed->getMeta(), Carbon::parse('2026-08-04T03:22:25.542Z'));
+        $this->assertEquals($refreshed->getTransactions(), Carbon::parse('2026-08-03T03:22:29.023Z'));
+        $this->assertEquals($refreshed->getParty(), Carbon::parse('2026-08-02T10:22:29.023Z'));
+    }
+}

--- a/tests/Unit/Services/Akahu/Model/Transaction/CategoryTest.php
+++ b/tests/Unit/Services/Akahu/Model/Transaction/CategoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Transactions;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\Category;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+final class CategoryTest extends TestCase
+{
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "_id": "nzfcc_ckouvvyxm004c08mlexbea79o",
+          "name": "Taxi, rideshare, and on-demand transport services",
+          "groups": {
+            "personal_finance": {
+              "_id": "group_clasr0ysw000whk4m577xhmf3",
+              "name": "Transport"
+            }
+          }
+        }';
+
+        $category = Category::fromJson(json_decode($json, true));
+
+        $this->assertSame($category->getNzfccId(), 'nzfcc_ckouvvyxm004c08mlexbea79o');
+        $this->assertSame($category->getName(), 'Taxi, rideshare, and on-demand transport services');
+        $this->assertSame($category->getPersonalFinanceGroup()?->getAkahuId(), 'group_clasr0ysw000whk4m577xhmf3');
+        $this->assertSame($category->getPersonalFinanceGroup()?->getName(), 'Transport');
+    }
+}
+

--- a/tests/Unit/Services/Akahu/Model/Transaction/ConversionTest.php
+++ b/tests/Unit/Services/Akahu/Model/Transaction/ConversionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Transactions;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\Conversion;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+use BcMath\Number;
+
+final class ConversionTest extends TestCase
+{
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "fee": 0.11,
+          "rate": 0.12,
+          "amount": 0.13,
+          "currency": "AUD"
+        }';
+
+        $conversion = Conversion::fromJson(json_decode($json, true));
+
+        $this->assertEquals($conversion->getAmount(), new Number('0.13'));
+        $this->assertEquals($conversion->getCurrency(), 'AUD');
+        $this->assertEquals($conversion->getRate(), new Number('0.12'));
+        $this->assertEquals($conversion->getFee(), new Number('0.11'));
+    }
+}
+

--- a/tests/Unit/Services/Akahu/Model/Transaction/MerchantTest.php
+++ b/tests/Unit/Services/Akahu/Model/Transaction/MerchantTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Transactions;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\Merchant;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+final class MerchantTest extends TestCase
+{
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "_id": "merchant_cksxp1au3001g09mp3ilt01tz",
+          "name": "The Wholemeal Cafe",
+          "website": "https://wholemealcafe.co.nz/"
+        }';
+
+        $merchant = Merchant::fromJson(json_decode($json, true));
+
+        $this->assertSame($merchant->getAkahuId(), 'merchant_cksxp1au3001g09mp3ilt01tz');
+        $this->assertSame($merchant->getName(), 'The Wholemeal Cafe');
+        $this->assertSame($merchant->getWebsite(), 'https://wholemealcafe.co.nz/');
+    }
+}
+

--- a/tests/Unit/Services/Akahu/Model/Transaction/MetaTest.php
+++ b/tests/Unit/Services/Akahu/Model/Transaction/MetaTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Transactions;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\Meta;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+use BcMath\Number;
+
+final class MetaTest extends TestCase
+{
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+            "particulars": "my particulars",
+            "code": "my code",
+            "reference": "my ref",
+
+            "other_account": "00-0000-0000000-00",
+
+            "conversion": {
+              "amount": 2.15,
+              "currency": "GBP",
+              "rate": 0.49
+            },
+
+            "card_suffix": "1234",
+            "logo": "https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa"
+        }';
+
+        $meta = Meta::fromJson(json_decode($json, true));
+
+        $this->assertEquals($meta->getParticulars(), 'my particulars');
+        $this->assertEquals($meta->getCode(), 'my code');
+        $this->assertEquals($meta->getReference(), 'my ref');
+        $this->assertEquals($meta->getOtherAccount(), '00-0000-0000000-00');
+        $this->assertEquals($meta->getConversion()?->getAmount(), new Number('2.15'));
+        $this->assertEquals($meta->getConversion()?->getCurrency(), 'GBP');
+        $this->assertEquals($meta->getConversion()?->getRate(), new Number('0.49'));
+        $this->assertEquals($meta->getCardSuffix(), '1234');
+        $this->assertEquals(
+            $meta->getLogo(),
+            'https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa'
+        );
+    }
+
+    public function testParseJson1(): void
+    {
+        $json = '{
+            "card_suffix": "1234",
+            "logo": "https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa"
+        }';
+
+        $meta = Meta::fromJson(json_decode($json, true));
+
+        $this->assertEquals($meta->getParticulars(), null);
+        $this->assertEquals($meta->getCode(), null);
+        $this->assertEquals($meta->getReference(), null);
+        $this->assertEquals($meta->getOtherAccount(), null);
+        $this->assertEquals($meta->getConversion()?->getAmount(), null);
+        $this->assertEquals($meta->getConversion()?->getCurrency(), null);
+        $this->assertEquals($meta->getConversion()?->getRate(), null);
+        $this->assertEquals($meta->getConversion()?->getFee(), null);
+        $this->assertEquals($meta->getCardSuffix(), '1234');
+        $this->assertEquals(
+            $meta->getLogo(),
+            'https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa'
+        );
+    }
+
+    public function testParseJson2(): void
+    {
+        $json = '{
+          "conversion": {
+            "fee": 0.22,
+            "rate": 0.44,
+            "amount": 12.34,
+            "currency": "AUD"
+          },
+          "card_suffix": "1234",
+          "logo": "https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa"
+        }';
+
+        $meta = Meta::fromJson(json_decode($json, true));
+
+        $this->assertEquals($meta->getParticulars(), null);
+        $this->assertEquals($meta->getCode(), null);
+        $this->assertEquals($meta->getReference(), null);
+        $this->assertEquals($meta->getOtherAccount(), null);
+        $this->assertEquals($meta->getConversion()?->getAmount(), new Number('12.34'));
+        $this->assertEquals($meta->getConversion()?->getCurrency(), 'AUD');
+        $this->assertEquals($meta->getConversion()?->getRate(), new Number('0.44'));
+        $this->assertEquals($meta->getConversion()?->getFee(), new Number('0.22'));
+        $this->assertEquals($meta->getCardSuffix(), '1234');
+        $this->assertEquals(
+            $meta->getLogo(),
+            'https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa'
+        );
+    }
+
+    public function testParseJson3(): void
+    {
+        $json = '{
+          "conversion": {
+            "fee": 0.11,
+            "rate": 0.99,
+            "amount": 1.11,
+            "currency": "NZD"
+          },
+          "card_suffix": "1234"
+        }';
+
+        $meta = Meta::fromJson(json_decode($json, true));
+
+        $this->assertEquals($meta->getParticulars(), null);
+        $this->assertEquals($meta->getCode(), null);
+        $this->assertEquals($meta->getReference(), null);
+        $this->assertEquals($meta->getOtherAccount(), null);
+        $this->assertEquals($meta->getConversion()?->getAmount(), new Number('1.11'));
+        $this->assertEquals($meta->getConversion()?->getCurrency(), 'NZD');
+        $this->assertEquals($meta->getConversion()?->getRate(), new Number('0.99'));
+        $this->assertEquals($meta->getConversion()?->getFee(), new Number('0.11'));
+        $this->assertEquals($meta->getCardSuffix(), '1234');
+        $this->assertEquals($meta->getLogo(), null);
+    }
+
+    public function testParseJson4(): void
+    {
+        $json = '{
+          "particulars": "Meow",
+          "code": "woeM",
+          "reference": "MEOW",
+          "other_account": "00-1111-2222222-33"
+        }';
+
+        $meta = Meta::fromJson(json_decode($json, true));
+
+        $this->assertEquals($meta->getParticulars(), 'Meow');
+        $this->assertEquals($meta->getCode(), 'woeM');
+        $this->assertEquals($meta->getReference(), 'MEOW');
+        $this->assertEquals($meta->getOtherAccount(), '00-1111-2222222-33');
+        $this->assertEquals($meta->getConversion()?->getAmount(), null);
+        $this->assertEquals($meta->getConversion()?->getCurrency(), null);
+        $this->assertEquals($meta->getConversion()?->getRate(), null);
+        $this->assertEquals($meta->getConversion()?->getFee(), null);
+        $this->assertEquals($meta->getCardSuffix(), null);
+        $this->assertEquals($meta->getLogo(), null);
+    }
+
+    // This can happen on transactions with type INTEREST
+    public function testParseJson5(): void
+    {
+        $json = '{}';
+
+        $meta = Meta::fromJson(json_decode($json, true));
+
+        $this->assertEquals($meta->getParticulars(), null);
+        $this->assertEquals($meta->getCode(), null);
+        $this->assertEquals($meta->getReference(), null);
+        $this->assertEquals($meta->getOtherAccount(), null);
+        $this->assertEquals($meta->getConversion()?->getAmount(), null);
+        $this->assertEquals($meta->getConversion()?->getCurrency(), null);
+        $this->assertEquals($meta->getConversion()?->getRate(), null);
+        $this->assertEquals($meta->getConversion()?->getFee(), null);
+        $this->assertEquals($meta->getCardSuffix(), null);
+        $this->assertEquals($meta->getLogo(), null);
+    }
+
+    public function testParseJson6(): void
+    {
+        $json = '{
+          "other_account": "11-22-3333333-44"
+        }';
+
+        $meta = Meta::fromJson(json_decode($json, true));
+
+        $this->assertEquals($meta->getParticulars(), null);
+        $this->assertEquals($meta->getCode(), null);
+        $this->assertEquals($meta->getReference(), null);
+        $this->assertEquals($meta->getOtherAccount(), '11-22-3333333-44');
+        $this->assertEquals($meta->getConversion()?->getAmount(), null);
+        $this->assertEquals($meta->getConversion()?->getCurrency(), null);
+        $this->assertEquals($meta->getConversion()?->getRate(), null);
+        $this->assertEquals($meta->getConversion()?->getFee(), null);
+        $this->assertEquals($meta->getCardSuffix(), null);
+        $this->assertEquals($meta->getLogo(), null);
+    }
+}

--- a/tests/Unit/Services/Akahu/Model/Transaction/PersonalFinanceGroupTest.php
+++ b/tests/Unit/Services/Akahu/Model/Transaction/PersonalFinanceGroupTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Transactions;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\PersonalFinanceGroup;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+final class PersonalFinanceGroupTest extends TestCase
+{
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "_id": "group_clasr0ysw0011hk4m6hlk9fq0",
+          "name": "Lifestyle"
+        }';
+
+        $pfg = PersonalFinanceGroup::fromJson(json_decode($json, true));
+
+        $this->assertEquals($pfg->getAkahuId(), 'group_clasr0ysw0011hk4m6hlk9fq0');
+        $this->assertEquals($pfg->getName(), 'Lifestyle');
+    }
+}
+

--- a/tests/Unit/Services/Akahu/Model/Transaction/TransactionTest.php
+++ b/tests/Unit/Services/Akahu/Model/Transaction/TransactionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Model\Transactions;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\Transaction;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+use BcMath\Number;
+
+final class TransactionTest extends TestCase
+{
+    public function testParseJsonFull(): void
+    {
+        $json = '{
+          "_id": "trans_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_account": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_user": "user_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "_connection": "conn_aaaaaaaaaaaaaaaaaaaaaaaaa",
+          "created_at": "2026-07-25T03:38:50.300Z",
+          "updated_at": "2026-07-25T03:38:51.536Z",
+          "date": "2026-06-29T11:39:52.000Z",
+          "description": "blah blah blah",
+          "amount": -100,
+          "balance": 1234567,
+          "type": "EFTPOS",
+          "hash": "acc_aaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "meta": {
+            "particulars": "Payment",
+            "code": "ref:1234",
+            "reference": "12345678",
+            "other_account": "11-2222-3333333-44",
+            "conversion": {
+              "fee": 0.11,
+              "rate": 0.22,
+              "amount": 0.33,
+              "currency": "USD"
+            },
+            "card_suffix": "1234",
+            "logo": "https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          "merchant": {
+            "_id": "merchant_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "Business",
+            "website": "https://business.com",
+            "nzbn": "1111111111111"
+          },
+          "category": {
+            "_id": "nzfcc_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "NZFCC Category name",
+            "groups": {
+              "personal_finance": {
+                "_id": "group_aaaaaaaaaaaaaaaaaaaaaaaaa",
+                "name": "Professional Services"
+              }
+            }
+          }
+        }';
+
+        $transaction = Transaction::fromJson(json_decode($json, true));
+
+        $this->assertEquals($transaction->getAkahuId(), 'trans_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertEquals($transaction->getAkahuAccountId(), 'acc_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertEquals($transaction->getCreatedAt(), Carbon::parse('2026-07-25T03:38:50.300Z'));
+        $this->assertEquals($transaction->getDate(), Carbon::parse('2026-06-29T11:39:52.000Z'));
+        $this->assertEquals($transaction->getDescription(), 'blah blah blah');
+        $this->assertEquals($transaction->getAmount(), new Number('-100'));
+        $this->assertEquals($transaction->getBalance(), new Number('1234567'));
+        $this->assertEquals($transaction->getType(), 'EFTPOS');
+
+        $this->assertEquals($transaction->getCategory()?->getNzfccId(), 'nzfcc_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertEquals($transaction->getCategory()?->getName(), 'NZFCC Category name');
+        $this->assertEquals($transaction->getCategory()?->getPersonalFinanceGroup()?->getAkahuId(), 'group_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertEquals($transaction->getCategory()?->getPersonalFinanceGroup()?->getName(), 'Professional Services');
+
+        $this->assertEquals($transaction->getMerchant()?->getAkahuId(), 'merchant_aaaaaaaaaaaaaaaaaaaaaaaaa');
+        $this->assertEquals($transaction->getMerchant()?->getName(), 'Business');
+        $this->assertEquals($transaction->getMerchant()?->getWebsite(), 'https://business.com');
+        $this->assertEquals($transaction->getMerchant()?->getNZBN(), '1111111111111');
+
+        $this->assertEquals($transaction->getMeta()?->getParticulars(), 'Payment');
+        $this->assertEquals($transaction->getMeta()?->getCode(), 'ref:1234');
+        $this->assertEquals($transaction->getMeta()?->getReference(), '12345678');
+        $this->assertEquals($transaction->getMeta()?->getOtherAccount(), '11-2222-3333333-44');
+
+        $this->assertEquals($transaction->getMeta()?->getConversion()?->getAmount(), new Number('0.33'));
+        $this->assertEquals($transaction->getMeta()?->getConversion()?->getCurrency(), 'USD');
+        $this->assertEquals($transaction->getMeta()?->getConversion()?->getRate(), new Number('0.22'));
+        $this->assertEquals($transaction->getMeta()?->getConversion()?->getFee(), new Number('0.11'));
+
+        $this->assertEquals($transaction->getMeta()?->getCardSuffix(), '1234');
+        $this->assertEquals($transaction->getMeta()?->getLogo(), 'https://cdn.akahu.nz/logos/merchants/merchant_aaaaaaaaaaaaaaaaaaaaaaaaa');
+    }
+}
+

--- a/tests/Unit/Services/Akahu/Request/AkahuDateRangeTest.php
+++ b/tests/Unit/Services/Akahu/Request/AkahuDateRangeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Akahu\Request;
+
+use App\Services\Shared\Configuration\Configuration;
+use App\Services\Akahu\Model\Transaction\Meta;
+use App\Services\Akahu\Model\Transaction\Transaction;
+use App\Services\Akahu\Conversion\NoteBuilder;
+use App\Services\Akahu\Request\AkahuDateRange;
+use Illuminate\Support\Facades\Config;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Session;
+use Override;
+use Tests\TestCase;
+
+//
+// Testing date range behaviour:
+// curl \
+//   -H "Authorization: Bearer user_token_aaaaaaaaaaaaaaaaaaaaaaaaa" \
+//   -H "X-Akahu-Id: app_token_aaaaaaaaaaaaaaaaaaaaaaaaa" \
+//   'https://api.akahu.io/v1/transactions?start=<start-iso>&end=<end-iso>' -v \
+//   | jq '.items.[] | {description:.description, date:.date, amount:.amount}'
+//
+
+final class AkahuDateRangeTest extends TestCase
+{
+    public function testOneDay(): void
+    {
+        Config::set('app.timezone', 'Pacific/Auckland');
+
+        $config = Configuration::fromArray([
+            'date_not_before' => '2026-08-13',
+            'date_not_after' => '2026-08-13',
+        ]);
+
+        $dateRange = new AkahuDateRange($config);
+
+        $this->assertEquals($dateRange->startDate()->toIsoString(), '2026-08-12T11:59:59.999000Z');
+        $this->assertEquals($dateRange->endDate()->toIsoString(), '2026-08-13T12:00:00.000000Z');
+    }
+
+    public function testMultipleDays(): void
+    {
+        Config::set('app.timezone', 'Pacific/Auckland');
+
+        $config = Configuration::fromArray([
+            'date_not_before' => '2026-08-10',
+            'date_not_after' => '2026-08-14',
+        ]);
+
+        $dateRange = new AkahuDateRange($config);
+
+        $this->assertEquals($dateRange->startDate()->toIsoString(), '2026-08-09T11:59:59.999000Z');
+        $this->assertEquals($dateRange->endDate()->toIsoString(), '2026-08-14T12:00:00.000000Z');
+    }
+
+    public function testOneSided(): void
+    {
+        Config::set('app.timezone', 'Pacific/Auckland');
+
+        $config = Configuration::fromArray([
+            'date_not_before' => '2026-08-13',
+            'date_not_after' => '',
+        ]);
+
+        $dateRange = new AkahuDateRange($config);
+
+        $this->assertEquals($dateRange->startDate()->toIsoString(), '2026-08-12T11:59:59.999000Z');
+        $this->assertEquals($dateRange->endDate()?->toIsoString(), null);
+    }
+}


### PR DESCRIPTION
<!--

🙌 Thanks for contributing a pull request. Before you continue:

1. If you introduce new third party data providers, talk to me FIRST.
2. If your PR is more than 25 lines, talk to me FIRST.
3. If you fix spelling or code comments, talk to me FIRST.

This is to prevent AI bots, low-effort PRs and spam. Sorry about that.

Wanna talk to me? Open a GitHub Issue, Discussion, or email me: james@firefly-iii.org

👀 Please ensure you have taken a look at the contribution guidelines:
https://docs.firefly-iii.org/explanation/support/#contributing-code

Remember that your PR may be CLOSED:

1. If you do not refer to an existing issue, your PR will be CLOSED.
2. If you open a PR on the main branch, your PR will be CLOSED.
3. If you only fix a spelling error or code comment, your PR will be CLOSED.

Again, this is to prevent AI bots, low-effort PRs and spam. I apologize for the harsh tone.

But if you made it this far thanks again for contributing, and happy developing!

-->

#### Reference issues and PRs
<!--
Example: Fixes #1234. See also #3456.
-->

#### What does this implement/fix? Explain your changes.

## Akahu data provider
[Akahu](https://www.akahu.nz/) is a New Zealand company that offers an API that gives access to ["Aggregate information from bank, investment, KiwiSaver, and other financial accounts"](https://www.akahu.nz/products-data).

This PR implements a data provider for the Akahu API via the free readonly ["Personal Account"](https://developers.akahu.nz/docs/personal-apps) tier. One major limitation of the personal account tier of Akahu is that only up to one [year of transactions](https://developers.akahu.nz/docs/accessing-transactional-data#getting-a-date-range:~:text=endpoint%2E-,Your,app,-%2E) can be read.

### API credentials
 - Navigate to [my.akahu.nz](https://my.akahu.nz/login) to create an Akahu profile.
 - Click the hamburger button in the top left, and click `Developers`.
 - Complete the KYC and MFA steps.
 - Create a personal app.
 - You should see an `App ID Token`. And under `User Access Token` it should say "Add accounts to generate a User Access token"
 - Connect a bank account to your profile and you should see both an `App ID Token` and a `User Access Token`.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://docs.firefly-iii.org/explanation/support/#automated-contributions-policy

If you remove or skip this disclosure, your PR may be ignored.
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
(The google search AI)

#### Any other comments?
 - Transfers are not great, NZ does not use IBAN's we only use domestic account numbers. I'm not sure how exactly to implement that as many of the other providers are IBAN based.
 - Dynamic currency precision when displaying amounts isn't implemented yet in the `bcstringify` calls. I'm not sure if `decimal_places` needs to be fetched from Firefly III or if its already stored somewhere locally.
 - Akahu transactions have a `type` field that isn't currently used but could be. Useful for type-hinting transfers.
 - Akahu sometimes provides a merchant logo which would be nice to display somewhere.
 - Akahu has support for other integrations such as New Zealand's [IRD](https://en.wikipedia.org/wiki/Inland_Revenue_Department_(New_Zealand)), In the future it would be interesting to look into adding support for those. 
<!--
Thanks for contributing!
-->

<img width="1916" height="945" alt="configuration" src="https://github.com/user-attachments/assets/a8932aa6-4986-436e-9697-0462d6bf5d0b" />

<img width="1916" height="905" alt="transaction" src="https://github.com/user-attachments/assets/bf611db6-9ba5-4ad9-9f60-f7baba248c2a" />


@JC5

