### PR TITLE
Treat empty downloads without errors as success for Lunch Flow and Enable Banking

### DIFF
--- a/app/Services/EnableBanking/Conversion/RoutineManager.php
+++ b/app/Services/EnableBanking/Conversion/RoutineManager.php
@@ -151,13 +151,31 @@ final class RoutineManager implements RoutineManagerInterface
             $total += count($transactions);
         }
 
-        if (0 === $total) {
+        if (0 === $total && $this->hasEnableBankingError()) {
             Log::warning('Downloaded nothing, will return nothing.');
             $this->importJob->conversionStatus->addError(0, '[eb003]: No transactions were downloaded from Enable Banking.');
             $this->repository->saveToDisk($this->importJob);
 
             return true;
         }
+
+        return false;
+    }
+
+    private function hasEnableBankingError(): bool
+    {
+        Log::debug('Check if Enable Banking had an error before we complain about not having transactions.');
+        $errors = $this->importJob->conversionStatus->errors;
+        foreach ($errors as $array) {
+            foreach ($array as $error) {
+                if (str_contains($error, 'eb001')) {
+                    Log::warning('Enable Banking had download error (eb001).');
+
+                    return true;
+                }
+            }
+        }
+        Log::debug('Enable Banking had no download error for this account.');
 
         return false;
     }

--- a/app/Services/LunchFlow/Conversion/RoutineManager.php
+++ b/app/Services/LunchFlow/Conversion/RoutineManager.php
@@ -148,7 +148,7 @@ final class RoutineManager implements RoutineManagerInterface
         foreach ($this->downloaded as $transactions) {
             $total += count($transactions);
         }
-        if (0 === $total) {
+        if (0 === $total && $this->hasLunchFlowError()) {
             Log::warning('Downloaded nothing, will return nothing.');
             // add error to current error thing:
             $this->importJob->conversionStatus->addError(
@@ -159,6 +159,24 @@ final class RoutineManager implements RoutineManagerInterface
 
             return true;
         }
+
+        return false;
+    }
+
+    private function hasLunchFlowError(): bool
+    {
+        Log::debug('Check if Lunch Flow had an error before we complain about not having transactions.');
+        $errors = $this->importJob->conversionStatus->errors;
+        foreach ($errors as $array) {
+            foreach ($array as $error) {
+                if (str_contains($error, 'a109')) {
+                    Log::warning('Lunch Flow had download error (a109).');
+
+                    return true;
+                }
+            }
+        }
+        Log::debug('Lunch Flow had no download error for this account.');
 
         return false;
     }

--- a/tests/Unit/Services/EnableBanking/Conversion/RoutineManagerTest.php
+++ b/tests/Unit/Services/EnableBanking/Conversion/RoutineManagerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * RoutineManagerTest.php
+ * Copyright (c) 2026 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\EnableBanking\Conversion;
+
+use App\Models\ImportJob;
+use App\Services\EnableBanking\Conversion\RoutineManager;
+use App\Services\Shared\Configuration\Configuration;
+use Illuminate\Support\Facades\Storage;
+use ReflectionMethod;
+use ReflectionProperty;
+use Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \App\Services\EnableBanking\Conversion\RoutineManager
+ */
+final class RoutineManagerTest extends TestCase
+{
+    private function makeManager(): RoutineManager
+    {
+        $job = ImportJob::createNew();
+        $job->setConfiguration(Configuration::make());
+
+        return new RoutineManager($job);
+    }
+
+    private function setDownloaded(RoutineManager $manager, array $downloaded): void
+    {
+        $property = new ReflectionProperty(RoutineManager::class, 'downloaded');
+        $property->setValue($manager, $downloaded);
+    }
+
+    private function breakOnDownload(RoutineManager $manager): bool
+    {
+        $method = new ReflectionMethod(RoutineManager::class, 'breakOnDownload');
+
+        return $method->invoke($manager);
+    }
+
+    /**
+     * @covers ::breakOnDownload
+     */
+    public function testEmptyDownloadWithoutDownloadErrorDoesNotBreak(): void
+    {
+        Storage::fake('import-jobs');
+        $manager = $this->makeManager();
+        $this->setDownloaded($manager, ['test-account' => []]);
+
+        self::assertFalse($this->breakOnDownload($manager));
+
+        $errors = $manager->getImportJob()->conversionStatus->errors;
+        self::assertSame([], $errors);
+    }
+
+    /**
+     * @covers ::breakOnDownload
+     */
+    public function testEmptyDownloadWithDownloadErrorAddsBreakError(): void
+    {
+        Storage::fake('import-jobs');
+        $manager = $this->makeManager();
+        $manager->getImportJob()->conversionStatus->addError(0, '[eb001]: Could not download from Enable Banking: test');
+        $this->setDownloaded($manager, ['test-account' => []]);
+
+        self::assertTrue($this->breakOnDownload($manager));
+
+        $errors = $manager->getImportJob()->conversionStatus->errors;
+        self::assertNotEmpty($errors[0]);
+        self::assertStringContainsString('[eb003]', implode(' ', $errors[0]));
+    }
+}

--- a/tests/Unit/Services/LunchFlow/Conversion/RoutineManagerTest.php
+++ b/tests/Unit/Services/LunchFlow/Conversion/RoutineManagerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * RoutineManagerTest.php
+ * Copyright (c) 2026 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\LunchFlow\Conversion;
+
+use App\Models\ImportJob;
+use App\Services\LunchFlow\Conversion\RoutineManager;
+use App\Services\Shared\Configuration\Configuration;
+use Illuminate\Support\Facades\Storage;
+use ReflectionMethod;
+use ReflectionProperty;
+use Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \App\Services\LunchFlow\Conversion\RoutineManager
+ */
+final class RoutineManagerTest extends TestCase
+{
+    private function makeManager(): RoutineManager
+    {
+        $job = ImportJob::createNew();
+        $job->setConfiguration(Configuration::make());
+
+        return new RoutineManager($job);
+    }
+
+    private function setDownloaded(RoutineManager $manager, array $downloaded): void
+    {
+        $property = new ReflectionProperty(RoutineManager::class, 'downloaded');
+        $property->setValue($manager, $downloaded);
+    }
+
+    private function breakOnDownload(RoutineManager $manager): bool
+    {
+        $method = new ReflectionMethod(RoutineManager::class, 'breakOnDownload');
+
+        return $method->invoke($manager);
+    }
+
+    /**
+     * @covers ::breakOnDownload
+     */
+    public function testEmptyDownloadWithoutDownloadErrorDoesNotBreak(): void
+    {
+        Storage::fake('import-jobs');
+        $manager = $this->makeManager();
+        $this->setDownloaded($manager, ['test-account' => []]);
+
+        self::assertFalse($this->breakOnDownload($manager));
+
+        $errors = $manager->getImportJob()->conversionStatus->errors;
+        self::assertSame([], $errors);
+    }
+
+    /**
+     * @covers ::breakOnDownload
+     */
+    public function testEmptyDownloadWithDownloadErrorAddsBreakError(): void
+    {
+        Storage::fake('import-jobs');
+        $manager = $this->makeManager();
+        $manager->getImportJob()->conversionStatus->addError(0, '[a109]: Could not download from GoCardless: test');
+        $this->setDownloaded($manager, ['test-account' => []]);
+
+        self::assertTrue($this->breakOnDownload($manager));
+
+        $errors = $manager->getImportJob()->conversionStatus->errors;
+        self::assertNotEmpty($errors[0]);
+        self::assertStringContainsString('[a111]', implode(' ', $errors[0]));
+    }
+}

--- a/tests/Unit/Services/Nordigen/Conversion/RoutineManagerTest.php
+++ b/tests/Unit/Services/Nordigen/Conversion/RoutineManagerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * RoutineManagerTest.php
+ * Copyright (c) 2026 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Nordigen\Conversion;
+
+use App\Models\ImportJob;
+use App\Services\Nordigen\Conversion\RoutineManager;
+use App\Services\Shared\Configuration\Configuration;
+use Illuminate\Support\Facades\Storage;
+use ReflectionMethod;
+use ReflectionProperty;
+use Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \App\Services\Nordigen\Conversion\RoutineManager
+ */
+final class RoutineManagerTest extends TestCase
+{
+    private function makeManager(): RoutineManager
+    {
+        $job = ImportJob::createNew();
+        $job->setConfiguration(Configuration::make());
+
+        return new RoutineManager($job);
+    }
+
+    private function setDownloaded(RoutineManager $manager, array $downloaded): void
+    {
+        $property = new ReflectionProperty(RoutineManager::class, 'downloaded');
+        $property->setValue($manager, $downloaded);
+    }
+
+    private function breakOnDownload(RoutineManager $manager): bool
+    {
+        $method = new ReflectionMethod(RoutineManager::class, 'breakOnDownload');
+
+        return $method->invoke($manager);
+    }
+
+    /**
+     * @covers ::breakOnDownload
+     */
+    public function testEmptyDownloadWithoutGoCardlessErrorDoesNotBreak(): void
+    {
+        Storage::fake('import-jobs');
+        $manager = $this->makeManager();
+        $this->setDownloaded($manager, ['test-account' => []]);
+
+        self::assertFalse($this->breakOnDownload($manager));
+
+        $errors = $manager->getImportJob()->conversionStatus->errors;
+        self::assertSame([], $errors);
+    }
+
+    /**
+     * @covers ::breakOnDownload
+     */
+    public function testEmptyDownloadWithGoCardlessErrorAddsBreakError(): void
+    {
+        Storage::fake('import-jobs');
+        $manager = $this->makeManager();
+        $manager->getImportJob()->conversionStatus->addError(0, '[a109]: Could not download from GoCardless: test');
+        $this->setDownloaded($manager, ['test-account' => []]);
+
+        self::assertTrue($this->breakOnDownload($manager));
+
+        $errors = $manager->getImportJob()->conversionStatus->errors;
+        self::assertNotEmpty($errors[0]);
+        self::assertStringContainsString('[a111]', implode(' ', $errors[0]));
+    }
+}


### PR DESCRIPTION
#### Reference issues and PRs

Fixes firefly-iii/firefly-iii#12419. The Nordigen half of this was already fixed in commit 222809b9; this applies the same fix to the other two providers and adds regression tests.

#### What does this implement/fix?

When a bank download succeeds but contains zero transactions, the conversion routine treated "zero downloaded" as a download failure: it added a "no transactions were downloaded" error to the conversion status, so the auto-upload endpoint aborted with "Too many errors in the data conversion" (HTTP 400). A quiet account or a date range with no new transactions is a valid empty result, not an error.

Commit 222809b9 fixed this for Nordigen by only reporting the empty download as an error when the download itself reported one. This PR applies that same gate to the Lunch Flow and Enable Banking conversion routines, and adds regression tests for all three providers: an empty download without a download error does not break the conversion, while an empty download with a real download error still reports the break error as before.

#### Any other comments?

The a109/a111 error strings inside the Lunch Flow routine (they mention GoCardless) are pre-existing copies from the Nordigen routine; left untouched here.

@JC5