### PR TITLE
Fix destIban check in Enable Banking GenerateTransactions

### DIFF
--- a/app/Services/EnableBanking/Conversion/Routine/GenerateTransactions.php
+++ b/app/Services/EnableBanking/Conversion/Routine/GenerateTransactions.php
@@ -238,7 +238,7 @@ final class GenerateTransactions
             }
 
             // Check if IBAN is a match, will overrule BBAN.
-            if (array_key_exists($destIban, $this->targetAccounts) && array_key_exists($bbanKey, $this->targetTypes)) {
+            if (array_key_exists($destIban, $this->targetAccounts) && array_key_exists($destIban, $this->targetTypes)) {
                 Log::debug(sprintf('Matched source IBAN "%s" to account #%d', $destIban, $this->targetAccounts[$destIban]));
                 if ('asset' === $this->targetTypes[$destIban]) {
                     Log::debug(sprintf(


### PR DESCRIPTION
#### Reference issues and PRs
Fixes firefly-iii/firefly-iii#12549

#### What does this implement/fix? Explain your changes.
Transfers between own accounts were mis-categorised as withdrawals when importing from the sending bank via Enable Banking. The negative-amount path in `GenerateTransactions::appendNegativeAmountInfo` checked `destIban` against `targetTypes[$bbanKey]` instead of `targetTypes[$destIban]`, so an IBAN that was known as an asset account was never recognised unless its BBAN also happened to be present. This corrects the second `array_key_exists` to use `$destIban`, mirroring `appendPositiveAmountInfo` which already checks `sourceIban` against `sourceIban`.

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?
Minimal one-line fix. No behaviour change for BBAN matching or non-asset types.

@JC5