### PR TITLE
Fix #12553: use DST-safe 89-day window for Enable Banking consent

### DIFF
--- a/app/Services/EnableBanking/Request/PostAuthRequest.php
+++ b/app/Services/EnableBanking/Request/PostAuthRequest.php
@@ -87,7 +87,7 @@ final class PostAuthRequest extends Request
      */
     public function post(): Response
     {
-        $validUntilTimestamp = $this->validUntil ?? strtotime('+90 days');
+        $validUntilTimestamp = $this->validUntil ?? time() + 7689600; // 89 days, DST-proof and within 7776000s limit
         $data                = [
             'access'       => ['valid_until' => date('c', $validUntilTimestamp)],
             'aspsp'        => ['name' => $this->aspsp, 'country' => $this->country],


### PR DESCRIPTION
#### Reference issues and PRs

Fixes firefly-iii/firefly-iii#12553

#### What does this implement/fix? Explain your changes.

Enable Banking `/auth` returned 422 when the 90-day consent window crossed the autumn DST fall-back, adding an extra hour over the 7776000s ASPSP limit. This changes the default window to an absolute 89-day offset which is DST-proof.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

@JC5