### PR TITLE
Fix #12541: allow null institution logo in LunchFlow Account

### DIFF
--- a/app/Services/LunchFlow/Model/Account.php
+++ b/app/Services/LunchFlow/Model/Account.php
@@ -30,7 +30,7 @@ namespace App\Services\LunchFlow\Model;
 final class Account
 {
     public int $id;
-    public string $institutionLogo;
+    public ?string $institutionLogo = null;
     public string $institutionName;
     public string $name;
     public string $provider;
@@ -49,7 +49,7 @@ final class Account
     {
         $model                  = new self();
         $model->id              = $data['id'];
-        $model->institutionLogo = $data['institution_logo'];
+        $model->institutionLogo = $data['institution_logo'] ?? null;
         $model->institutionName = $data['institution_name'];
         $model->name            = $data['name'];
         $model->provider        = $data['provider'];


### PR DESCRIPTION
#### Reference issues and PRs

Fixes firefly-iii/firefly-iii#12541

#### What does this implement/fix? Explain your changes.

LunchFlow returns `null` for `institution_logo` when an institution has no logo, but the Account model required a non-nullable string and threw a TypeError before the account list could be displayed. This makes the logo property nullable with a null default and handles missing values the same way as `currency` and `status`.

#### Any other comments?

Minimal two-line fix, no other files changed.

@JC5